### PR TITLE
Update version to 1.1.1 and improve updater logic

### DIFF
--- a/IconSwapperGui.Updater/IconSwapperGui.Updater.csproj
+++ b/IconSwapperGui.Updater/IconSwapperGui.Updater.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="HtmlAgilityPack" Version="1.11.61" />
+      <PackageReference Include="HtmlAgilityPack" Version="1.11.67" />
     </ItemGroup>
 
 </Project>

--- a/IconSwapperGui/IconSwapperGui.csproj
+++ b/IconSwapperGui/IconSwapperGui.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>favicon.ico</ApplicationIcon>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <Authors>Adam Phillips</Authors>
   </PropertyGroup>
 
@@ -23,9 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="13.9.1" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.1" />
-    <PackageReference Include="WindowsAPICodePack" Version="7.0.4" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.8" />
+    <PackageReference Include="WindowsAPICodePack" Version="8.0.4" />
   </ItemGroup>
 
 </Project>

--- a/IconSwapperGui/MainWindow.xaml.cs
+++ b/IconSwapperGui/MainWindow.xaml.cs
@@ -27,7 +27,14 @@ namespace IconSwapperGui
         {
             var updaterExePath = Path.Combine(_currentAssemblyDirectory, "IconSwapperGui.Updater.exe");
 
-            Process.Start(updaterExePath, _currentVersion);
+            if (File.Exists(updaterExePath))
+            {
+                Process.Start(updaterExePath, _currentVersion);
+            }
+            else
+            {
+                MessageBox.Show("Updater could not be found. The application will start without updating.", "Updater Not Found", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
         }
     }
 }

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "LatestVersion": "1.1.0"
+  "LatestVersion": "1.1.1"
 }


### PR DESCRIPTION
Updated project and package versions to 1.1.1 and the latest stable releases. Added a check to ensure the updater executable exists before attempting to start it and provided a user-friendly message if it's missing.