### PR TITLE
Add context menu commands for icons

### DIFF
--- a/IconSwapperGui/Commands/Swapper/ContextMenu/CopyPathContextCommand.cs
+++ b/IconSwapperGui/Commands/Swapper/ContextMenu/CopyPathContextCommand.cs
@@ -1,0 +1,25 @@
+﻿using System.Windows;
+using IconSwapperGui.Models;
+using IconSwapperGui.ViewModels;
+
+namespace IconSwapperGui.Commands.Swapper.ContextMenu;
+
+public class CopyPathContextCommand : RelayCommand
+{
+    private readonly SwapperViewModel _viewModel;
+
+    public CopyPathContextCommand(SwapperViewModel viewModel, Action<object> execute = null,
+        Func<object, bool>? canExecute = null)
+        : base(execute, canExecute)
+    {
+        _viewModel = viewModel;
+    }
+
+    public override void Execute(object? parameter)
+    {
+        if (_viewModel.SelectedIcon is not null)
+        {
+            Clipboard.SetText(_viewModel.SelectedIcon.Path);
+        }
+    }
+}

--- a/IconSwapperGui/Commands/Swapper/ContextMenu/DeleteIconContextCommand.cs
+++ b/IconSwapperGui/Commands/Swapper/ContextMenu/DeleteIconContextCommand.cs
@@ -1,0 +1,40 @@
+﻿using System.IO;
+using System.Windows;
+using IconSwapperGui.Models;
+using IconSwapperGui.ViewModels;
+using Application = System.Windows.Application;
+
+namespace IconSwapperGui.Commands.Swapper.ContextMenu;
+
+public class DeleteIconContextCommand : RelayCommand
+{
+    private readonly SwapperViewModel _viewModel;
+
+    public DeleteIconContextCommand(SwapperViewModel viewModel, Action<object> execute = null,
+        Func<object, bool>? canExecute = null)
+        : base(execute, canExecute)
+    {
+        _viewModel = viewModel;
+    }
+
+    public override void Execute(object? parameter)
+    {
+        var iconToDelete = _viewModel.SelectedIcon;
+        if (iconToDelete == null || !File.Exists(iconToDelete.Path)) return;
+
+        try
+        {
+            File.Delete(iconToDelete.Path);
+        }
+        catch (Exception e)
+        {
+            MessageBox.Show(e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            return;
+        }
+
+        Application.Current.Dispatcher.Invoke(() => { _viewModel.Icons.Remove(iconToDelete); });
+
+        _viewModel.FilterIcons();
+        _viewModel.PopulateIconsList(_viewModel.IconsFolderPath);
+    }
+}

--- a/IconSwapperGui/Commands/Swapper/ContextMenu/DuplicateIconContextCommand.cs
+++ b/IconSwapperGui/Commands/Swapper/ContextMenu/DuplicateIconContextCommand.cs
@@ -1,0 +1,41 @@
+﻿using System.IO;
+using IconSwapperGui.Models;
+using IconSwapperGui.ViewModels;
+
+namespace IconSwapperGui.Commands.Swapper.ContextMenu;
+
+public class DuplicateIconContextCommand : RelayCommand
+{
+    private readonly SwapperViewModel _viewModel;
+
+    public DuplicateIconContextCommand(SwapperViewModel viewModel, Action<object> execute = null,
+        Func<object, bool>? canExecute = null)
+        : base(execute, canExecute)
+    {
+        _viewModel = viewModel;
+    }
+
+    public override void Execute(object? parameter)
+    {
+        if (_viewModel.SelectedIcon is null)
+            return;
+        
+        var directory = Path.GetDirectoryName(_viewModel.SelectedIcon.Path);
+        var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(_viewModel.SelectedIcon.Path);
+        var extension = Path.GetExtension(_viewModel.SelectedIcon.Path);
+        var newFileName = $"{fileNameWithoutExtension} - Copy{extension}";
+        var newFilePath = Path.Combine(directory, newFileName);
+
+        var count = 1;
+        
+        while (File.Exists(newFilePath))
+        {
+            newFileName = $"{fileNameWithoutExtension} - Copy ({count++}){extension}";
+            newFilePath = Path.Combine(directory, newFileName);
+        }
+
+        File.Copy(_viewModel.SelectedIcon.Path, newFilePath);
+            
+        _viewModel.PopulateIconsList(_viewModel.IconsFolderPath);
+    }
+}

--- a/IconSwapperGui/Commands/Swapper/ContextMenu/OpenExplorerContextCommand.cs
+++ b/IconSwapperGui/Commands/Swapper/ContextMenu/OpenExplorerContextCommand.cs
@@ -1,0 +1,27 @@
+﻿using System.Diagnostics;
+using System.IO;
+using IconSwapperGui.Models;
+using IconSwapperGui.ViewModels;
+
+namespace IconSwapperGui.Commands.Swapper.ContextMenu;
+
+public class OpenExplorerContextCommand : RelayCommand
+{
+    private readonly SwapperViewModel _viewModel;
+
+    public OpenExplorerContextCommand(SwapperViewModel viewModel, Action<object> execute = null,
+        Func<object, bool>? canExecute = null)
+        : base(execute, canExecute)
+    {
+        _viewModel = viewModel;
+    }
+
+    public override void Execute(object? parameter)
+    {
+        if (_viewModel.SelectedIcon is not null && File.Exists(_viewModel.SelectedIcon.Path))
+        {
+            Process.Start(new ProcessStartInfo("explorer.exe", $"/select, \"{_viewModel.SelectedIcon.Path}\"")
+                { UseShellExecute = true });
+        }
+    }
+}

--- a/IconSwapperGui/IconSwapperGui.csproj
+++ b/IconSwapperGui/IconSwapperGui.csproj
@@ -7,7 +7,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <UseWPF>true</UseWPF>
         <ApplicationIcon>favicon.ico</ApplicationIcon>
-        <Version>1.5.0</Version>
+        <Version>1.6.0</Version>
         <Authors>Adam Phillips</Authors>
     </PropertyGroup>
 

--- a/IconSwapperGui/UserControls/SwapperUserControl.xaml
+++ b/IconSwapperGui/UserControls/SwapperUserControl.xaml
@@ -6,7 +6,6 @@
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:utilities="clr-namespace:IconSwapperGui.Utilities"
              mc:Ignorable="d" Height="540" Width="995">
-
     <UserControl.Resources>
         <utilities:IconPathToImageConverter x:Key="IconPathToImageConverter" />
         <utilities:ApplicationPathToImageConverter x:Key="ApplicationPathToImageConverter" />
@@ -23,7 +22,6 @@
             <ColumnDefinition Width="5*" />
         </Grid.ColumnDefinitions>
 
-        <!-- Application Selector Group -->
         <materialDesign:Card Grid.Row="0" Grid.Column="0" Margin="10" materialDesign:ElevationAssist.Elevation="Dp3">
             <StackPanel>
                 <TextBlock Text="Applications"
@@ -31,12 +29,10 @@
                            Margin="10,10,10,5"
                            HorizontalAlignment="Center"
                            Style="{DynamicResource MaterialDesignHeadline6TextBlockStyle}" />
-
                 <Button Name="ChooseApplicationShortcutFolderButton"
                         Command="{Binding ChooseApplicationShortcutFolderCommand}"
                         Margin="10"
                         Style="{StaticResource MaterialDesignRaisedDarkButton}">
-
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
@@ -86,7 +82,6 @@
             </StackPanel>
         </materialDesign:Card>
 
-        <!-- Icon Selector Group -->
         <materialDesign:Card Grid.Row="0" Grid.Column="1" Margin="10" materialDesign:ElevationAssist.Elevation="Dp3">
             <StackPanel>
                 <TextBlock Text="Icons"
@@ -94,7 +89,6 @@
                            Margin="10,10,10,5"
                            HorizontalAlignment="Center"
                            Style="{DynamicResource MaterialDesignHeadline6TextBlockStyle}" />
-
                 <Grid Margin="22,10,22,0">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
@@ -107,7 +101,6 @@
                              Style="{StaticResource MaterialDesignOutlinedTextBox}" Grid.Column="0"
                              HorizontalAlignment="Left" Margin="0,0,10,0" />
 
-                    <!-- Choose Icon Folder Button -->
                     <Button Name="ChooseIconFolderButton"
                             Command="{Binding ChooseIconFolderCommand}"
                             Style="{StaticResource MaterialDesignRaisedDarkButton}" Grid.Column="1">
@@ -131,6 +124,7 @@
                          ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                          ScrollViewer.VerticalScrollBarVisibility="Auto"
                          Height="300">
+
                     <ListBox.Resources>
                         <Style TargetType="ListBoxItem">
                             <Setter Property="Background" Value="Transparent" />
@@ -146,6 +140,7 @@
                             </Style.Triggers>
                         </Style>
                     </ListBox.Resources>
+
                     <ListBox.ItemTemplate>
                         <DataTemplate>
                             <Border HorizontalAlignment="Center" VerticalAlignment="Center" Width="100" Height="100">
@@ -170,16 +165,31 @@
                             </Border>
                         </DataTemplate>
                     </ListBox.ItemTemplate>
+
                     <ListBox.ItemsPanel>
                         <ItemsPanelTemplate>
                             <WrapPanel HorizontalAlignment="Center" ItemHeight="100" ItemWidth="100" />
                         </ItemsPanelTemplate>
                     </ListBox.ItemsPanel>
+
+                    <ListBox.ContextMenu>
+                        <ContextMenu>
+                            <MenuItem Header="Open in Explorer"
+                                      Command="{Binding OpenExplorerContextCommand}" />
+                            <MenuItem Header="Copy Path"
+                                      Command="{Binding CopyPathContextCommand}" />
+                            <Separator />
+                            <MenuItem Header="Duplicate"
+                                      Command="{Binding DuplicateIconContextCommand}" />
+                            <Separator />
+                            <MenuItem Header="Delete"
+                                      Command="{Binding DeleteIconContextCommand}" />
+                        </ContextMenu>
+                    </ListBox.ContextMenu>
                 </ListBox>
             </StackPanel>
         </materialDesign:Card>
 
-        <!-- Swap Button with Tick Icon -->
         <Grid Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Margin="10" HorizontalAlignment="Center">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
@@ -188,7 +198,8 @@
             <Button Command="{Binding SwapCommand}"
                     Width="140"
                     HorizontalAlignment="Center"
-                    Style="{StaticResource MaterialDesignRaisedDarkButton}">
+                    Style="{StaticResource MaterialDesignRaisedDarkButton}"
+                    IsEnabled="{Binding CanSwapIcons}">
                 <Grid>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />

--- a/IconSwapperGui/ViewModels/SettingsViewModel.cs
+++ b/IconSwapperGui/ViewModels/SettingsViewModel.cs
@@ -104,7 +104,7 @@ public class SettingsViewModel : ViewModel
         var themeUri = IsDarkModeEnabled == true
             ? new Uri("pack://application:,,,/Themes/DarkTheme.xaml")
             : new Uri("pack://application:,,,/Themes/LightTheme.xaml");
-
+        
         Application.Current.Resources.MergedDictionaries.Clear();
         Application.Current.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = themeUri });
     }

--- a/IconSwapperGui/ViewModels/SwapperViewModel.cs
+++ b/IconSwapperGui/ViewModels/SwapperViewModel.cs
@@ -4,10 +4,10 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using IconSwapperGui.Commands;
 using IconSwapperGui.Commands.Swapper;
+using IconSwapperGui.Commands.Swapper.ContextMenu;
 using IconSwapperGui.Interfaces;
 using IconSwapperGui.Models;
 using IconSwapperGui.Services;
-using Application = IconSwapperGui.Models.Application;
 
 namespace IconSwapperGui.ViewModels;
 
@@ -50,6 +50,10 @@ public class SwapperViewModel : ViewModel, IIconViewModel, INotifyPropertyChange
         ChooseApplicationShortcutFolderCommand = new ChooseApplicationShortcutFolderCommand(this, null!, x => true);
         ChooseIconFolderCommand = new ChooseIconFolderCommand<SwapperViewModel>(this, null!, x => true);
         SwapCommand = new SwapCommand(this, null!, x => true);
+        CopyPathContextCommand = new CopyPathContextCommand(this);
+        DeleteIconContextCommand = new DeleteIconContextCommand(this);
+        DuplicateIconContextCommand = new DuplicateIconContextCommand(this);
+        OpenExplorerContextCommand = new OpenExplorerContextCommand(this);
 
         LoadPreviousApplications();
         LoadPreviousIcons();
@@ -112,6 +116,10 @@ public class SwapperViewModel : ViewModel, IIconViewModel, INotifyPropertyChange
     public RelayCommand ChooseApplicationShortcutFolderCommand { get; }
     public RelayCommand ChooseIconFolderCommand { get; }
     public RelayCommand SwapCommand { get; }
+    public RelayCommand CopyPathContextCommand { get; }
+    public RelayCommand DeleteIconContextCommand { get; }
+    public RelayCommand DuplicateIconContextCommand { get; }
+    public RelayCommand OpenExplorerContextCommand { get; }
 
     public string ApplicationsFolderPath
     {
@@ -182,7 +190,11 @@ public class SwapperViewModel : ViewModel, IIconViewModel, INotifyPropertyChange
         foreach (var icon in icons)
         {
             if (Icons.Any(x => x.Path == icon.Path)) continue;
-            Icons.Add(icon);
+            
+            System.Windows.Application.Current.Dispatcher.Invoke(() =>
+            {
+                Icons.Add(icon);
+            });
         }
 
         FilterIcons();
@@ -208,7 +220,7 @@ public class SwapperViewModel : ViewModel, IIconViewModel, INotifyPropertyChange
 
     private void OnIconsDirectoryChanged(object sender, FileSystemEventArgs e)
     {
-        PopulateIconsList(IconsFolderPath);
+        System.Windows.Application.Current.Dispatcher.Invoke(() => PopulateIconsList(IconsFolderPath));
     }
 
     private void OnIconsDirectoryRenamed(object sender, RenamedEventArgs e)

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "LatestVersion": "1.5.0"
+  "LatestVersion": "1.6.0"
 }


### PR DESCRIPTION
Introduced new context menu commands to manage icons: duplicate, delete, copy path, and open in explorer. Updated `SwapperViewModel` to support these commands and ensured UI components are linked to the new functionality. Incremented version from 1.5.0 to 1.6.0 due to significant feature additions.