### PR TITLE
ICS-009 - Fix Transparent Exporting Issues

### DIFF
--- a/IconSwapperGui/Commands/PixelArtEditor/ExportIconCommand.cs
+++ b/IconSwapperGui/Commands/PixelArtEditor/ExportIconCommand.cs
@@ -1,11 +1,14 @@
 using System.IO;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
 using IconSwapperGui.Helpers;
 using IconSwapperGui.ViewModels;
 using ImageMagick;
 using Microsoft.Win32;
+using Path = System.IO.Path;
 
 namespace IconSwapperGui.Commands.PixelArtEditor;
 
@@ -23,16 +26,12 @@ public class ExportIconCommand : RelayCommand
 
     public override void Execute(object? parameter)
     {
-        var canvas = _viewModel.DrawableCanvas;
-
-        if (canvas == null) return;
-
         var folderPath = OpenFolderDialog();
         if (string.IsNullOrEmpty(folderPath)) return;
 
-        CanvasHelper.GetDpi(canvas, out _canvasDpiX, out _canvasDpiY);
+        CanvasHelper.GetDpi(_viewModel.DrawableCanvas, out _canvasDpiX, out _canvasDpiY);
 
-        var pngPath = SaveCanvasAsPng(canvas, folderPath);
+        var pngPath = SaveCanvasAsPngForExport(folderPath);
         if (string.IsNullOrEmpty(pngPath)) return;
 
         CreateAndSaveIcon(pngPath, folderPath);
@@ -43,14 +42,43 @@ public class ExportIconCommand : RelayCommand
     private static string OpenFolderDialog()
     {
         var openFolderDialog = new OpenFolderDialog();
-        
+
         return openFolderDialog.ShowDialog() == true ? openFolderDialog.FolderName : string.Empty;
+    }
+
+    private string SaveCanvasAsPngForExport(string folderPath)
+    {
+        var exportCanvas = new Canvas
+        {
+            Width = _viewModel.DrawableCanvas.ActualWidth,
+            Height = _viewModel.DrawableCanvas.ActualHeight,
+            Background = new SolidColorBrush(_viewModel.BackgroundColor)
+        };
+
+        foreach (var pixelRect in _viewModel.Pixels)
+        {
+            var exportRect = new Rectangle
+            {
+                Width = pixelRect.Width,
+                Height = pixelRect.Height,
+                Fill = pixelRect.Fill,
+                Stroke = pixelRect.Stroke,
+                StrokeThickness = _viewModel.BackgroundColor == Colors.Transparent ? 0 : pixelRect.StrokeThickness
+            };
+
+            Canvas.SetLeft(exportRect, Canvas.GetLeft(pixelRect));
+            Canvas.SetTop(exportRect, Canvas.GetTop(pixelRect));
+
+            exportCanvas.Children.Add(exportRect);
+        }
+
+        return SaveCanvasAsPng(exportCanvas, folderPath);
     }
 
     private string SaveCanvasAsPng(FrameworkElement canvas, string folderPath)
     {
-        var width = (int)canvas.ActualWidth;
-        var height = (int)canvas.ActualHeight;
+        var width = (int)canvas.Width;
+        var height = (int)canvas.Height;
 
         var renderBitmap = new RenderTargetBitmap(width, height, _canvasDpiX, _canvasDpiY, PixelFormats.Pbgra32);
 
@@ -64,9 +92,9 @@ public class ExportIconCommand : RelayCommand
         {
             using var fileStream = new FileStream(pngPath, FileMode.Create);
             var encoder = new PngBitmapEncoder();
-            
+
             encoder.Frames.Add(BitmapFrame.Create(renderBitmap));
-            
+
             encoder.Save(fileStream);
         }
         catch (Exception)
@@ -80,11 +108,13 @@ public class ExportIconCommand : RelayCommand
     private void CreateAndSaveIcon(string pngPath, string folderPath)
     {
         using var image = new MagickImage(pngPath);
+        image.Alpha(AlphaOption.On);
 
         const int targetSize = 128;
         image.Resize(targetSize, targetSize);
 
         using var finalImage = new MagickImage(MagickColors.Transparent, targetSize, targetSize);
+        finalImage.Alpha(AlphaOption.On);
         var offsetX = (int)(targetSize - image.Width) / 2;
         var offsetY = (int)(targetSize - image.Height) / 2;
 
@@ -97,9 +127,6 @@ public class ExportIconCommand : RelayCommand
 
     private static void DeleteTemporaryFile(string filePath)
     {
-        if (File.Exists(filePath))
-        {
-            File.Delete(filePath);
-        }
+        if (File.Exists(filePath)) File.Delete(filePath);
     }
 }

--- a/IconSwapperGui/IconSwapperGui.csproj
+++ b/IconSwapperGui/IconSwapperGui.csproj
@@ -7,7 +7,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <UseWPF>true</UseWPF>
         <ApplicationIcon>favicon.ico</ApplicationIcon>
-        <Version>1.7.1</Version>
+        <Version>1.7.2</Version>
         <Authors>Adam Phillips</Authors>
     </PropertyGroup>
 
@@ -20,14 +20,14 @@
 
     <ItemGroup>
         <Content Include="favicon.ico"/>
-        <None Remove="IWshRuntimeLibrary.dll" />
+        <None Remove="IWshRuntimeLibrary.dll"/>
         <Content Include="IWshRuntimeLibrary.dll">
-          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Extended.Wpf.Toolkit" Version="4.6.1" />
+        <PackageReference Include="Extended.Wpf.Toolkit" Version="4.6.1"/>
         <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.0.0"/>
         <PackageReference Include="MaterialDesignThemes" Version="5.1.0"/>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "LatestVersion": "1.7.1"
+  "LatestVersion": "1.7.2"
 }


### PR DESCRIPTION
Added a new method that basically duplicates the canvas and recreates the pixel art using the data stored in the Pixels collection, but with the stroke disabled for transparent backgrounds.

Additionally added missing code to support transparency when converting to a PNG.

