### PR TITLE
ICS-011 - Reset Shortcut Icons To Default

### DIFF
--- a/IconSwapperGui/Commands/Swapper/ChooseIconFolderCommand.cs
+++ b/IconSwapperGui/Commands/Swapper/ChooseIconFolderCommand.cs
@@ -1,5 +1,5 @@
-﻿using IconSwapperGui.Interfaces;
-using IconSwapperGui.ViewModels;
+﻿using IconSwapperGui.ViewModels;
+using IconSwapperGui.ViewModels.Interfaces;
 using Microsoft.WindowsAPICodePack.Dialogs;
 
 namespace IconSwapperGui.Commands.Swapper;

--- a/IconSwapperGui/Commands/Swapper/ContextMenu/ResetIconContextCommand.cs
+++ b/IconSwapperGui/Commands/Swapper/ContextMenu/ResetIconContextCommand.cs
@@ -1,0 +1,153 @@
+﻿using System.IO;
+using System.Windows;
+using IconSwapperGui.Helpers;
+using IconSwapperGui.ViewModels;
+using Microsoft.Win32;
+using Microsoft.WindowsAPICodePack.Dialogs;
+using ApplicationModel = IconSwapperGui.Models.Application;
+
+namespace IconSwapperGui.Commands.Swapper.ContextMenu;
+
+public class ResetIconContextCommand : RelayCommand
+{
+    private const string LnkExtension = ".lnk";
+    private const string UrlExtension = ".url";
+    private const string SteamRegistryPath = @"Software\Valve\Steam";
+    private const string SteamPathKey = "SteamPath";
+    private readonly LnkIconSwapper _lnkIconSwapper;
+    private readonly UrlIconSwapper _urlIconSwapper;
+    private readonly SwapperViewModel _viewModel;
+
+    public ResetIconContextCommand(SwapperViewModel viewModel, Action<object> execute = null!,
+        Func<object, bool>? canExecute = null)
+        : base(execute, canExecute)
+    {
+        _viewModel = viewModel;
+        _lnkIconSwapper = new LnkIconSwapper(viewModel.DialogService, viewModel.ElevationService);
+        _urlIconSwapper = new UrlIconSwapper();
+    }
+
+    public override void Execute(object? parameter)
+    {
+        var applicationToReset = _viewModel.SelectedApplication;
+
+        if (applicationToReset == null || !File.Exists(applicationToReset.Path))
+            return;
+
+        try
+        {
+            if (ShouldResetAutomatically(applicationToReset))
+            {
+                ResetIconAutomatically(applicationToReset);
+            }
+            else
+            {
+                if (!PromptManualReset())
+                    return;
+
+                var manualIconPath = GetManualIconPath(applicationToReset);
+                if (manualIconPath == null)
+                    return;
+
+                ResetIconManually(applicationToReset, manualIconPath);
+            }
+
+            RefreshApplicationsList();
+        }
+        catch (Exception e)
+        {
+            ShowErrorMessage(e.Message);
+        }
+    }
+
+    private static bool ShouldResetAutomatically(ApplicationModel application)
+    {
+        return application.DefaultTargetPath != null &&
+               application.DefaultTargetPath.EndsWith(".exe", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private void ResetIconAutomatically(ApplicationModel application)
+    {
+        var fileExtension = Path.GetExtension(application.Path).ToLower();
+
+        switch (fileExtension)
+        {
+            case LnkExtension:
+                _lnkIconSwapper.Swap(application.Path, application.DefaultTargetPath!, application.Name);
+                break;
+            case UrlExtension:
+                _urlIconSwapper.Swap(application.Path, application.DefaultTargetPath!);
+                break;
+            default:
+                throw new InvalidOperationException("Unsupported file extension for automatic reset.");
+        }
+    }
+
+    private static bool PromptManualReset()
+    {
+        var result = MessageBox.Show(
+            "Unfortunately, this icon needs to be reset manually.\n\nWould you like to proceed?",
+            "Error Resetting Icon Automatically",
+            MessageBoxButton.YesNo,
+            MessageBoxImage.Question);
+
+        return result == MessageBoxResult.Yes;
+    }
+
+    private static string? GetManualIconPath(ApplicationModel application)
+    {
+        var steamPath = GetSteamPath() + "/steam/games";
+
+        using var chooseIconDialog = new CommonOpenFileDialog();
+        chooseIconDialog.Title = "Choose Icon";
+        chooseIconDialog.InitialDirectory = GetInitialDirectory(application, steamPath);
+
+        return chooseIconDialog.ShowDialog() == CommonFileDialogResult.Ok
+            ? chooseIconDialog.FileName
+            : null;
+    }
+
+    private void ResetIconManually(ApplicationModel application, string iconPath)
+    {
+        if (!File.Exists(iconPath))
+            return;
+
+        var fileExtension = Path.GetExtension(application.Path).ToLower();
+
+        switch (fileExtension)
+        {
+            case LnkExtension:
+                _lnkIconSwapper.Swap(application.Path, iconPath, application.Name);
+                break;
+            case UrlExtension:
+                _urlIconSwapper.Swap(application.Path, iconPath);
+                break;
+            default:
+                throw new InvalidOperationException("Unsupported file extension for manual reset.");
+        }
+    }
+
+    private static string? GetSteamPath()
+    {
+        return Registry.CurrentUser.OpenSubKey(SteamRegistryPath)?.GetValue(SteamPathKey)?.ToString();
+    }
+
+    private static string GetInitialDirectory(ApplicationModel application, string? steamPath)
+    {
+        if (steamPath != null &&
+            application.DefaultTargetPath?.Contains("steam", StringComparison.OrdinalIgnoreCase) == true)
+            return steamPath;
+
+        return Path.GetDirectoryName(application.Path) ?? string.Empty;
+    }
+
+    private void RefreshApplicationsList()
+    {
+        _viewModel.PopulateApplicationsList(_viewModel.ApplicationsFolderPath);
+    }
+
+    private static void ShowErrorMessage(string message)
+    {
+        MessageBox.Show(message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+    }
+}

--- a/IconSwapperGui/Commands/Swapper/ContextMenu/ResetIconContextCommand.cs
+++ b/IconSwapperGui/Commands/Swapper/ContextMenu/ResetIconContextCommand.cs
@@ -96,7 +96,7 @@ public class ResetIconContextCommand : RelayCommand
 
     private static string? GetManualIconPath(ApplicationModel application)
     {
-        var steamPath = GetSteamPath() + "/steam/games";
+        var steamPath = GetSteamPath() + "steam\\games";
 
         using var chooseIconDialog = new CommonOpenFileDialog();
         chooseIconDialog.Title = "Choose Icon";
@@ -129,7 +129,9 @@ public class ResetIconContextCommand : RelayCommand
 
     private static string? GetSteamPath()
     {
-        return Registry.CurrentUser.OpenSubKey(SteamRegistryPath)?.GetValue(SteamPathKey)?.ToString();
+        var steamPath = Registry.CurrentUser.OpenSubKey(SteamRegistryPath)?.GetValue(SteamPathKey)?.ToString();
+
+        return steamPath?.Replace("/", "\\") + (steamPath.EndsWith('\\') ? string.Empty : "\\");
     }
 
     private static string GetInitialDirectory(ApplicationModel application, string? steamPath)

--- a/IconSwapperGui/Helpers/LnkIconSwapper.cs
+++ b/IconSwapperGui/Helpers/LnkIconSwapper.cs
@@ -1,5 +1,5 @@
 using System.IO;
-using IconSwapperGui.Interfaces;
+using IconSwapperGui.Services.Interfaces;
 using IWshRuntimeLibrary;
 
 namespace IconSwapperGui.Helpers;

--- a/IconSwapperGui/IconSwapperGui.csproj
+++ b/IconSwapperGui/IconSwapperGui.csproj
@@ -7,7 +7,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <UseWPF>true</UseWPF>
         <ApplicationIcon>favicon.ico</ApplicationIcon>
-        <Version>1.8.0</Version>
+        <Version>1.8.1</Version>
         <Authors>Adam Phillips</Authors>
     </PropertyGroup>
 

--- a/IconSwapperGui/Models/Application.cs
+++ b/IconSwapperGui/Models/Application.cs
@@ -8,14 +8,16 @@ public class Application
         Path = path;
     }
 
-    public Application(string name, string path, string targetPath)
+    public Application(string name, string path, string defaultTargetPath, string targetPath)
     {
         Name = name;
         Path = path;
+        DefaultTargetPath = defaultTargetPath;
         TargetPath = targetPath;
     }
 
     public string Name { get; set; }
     public string Path { get; set; }
+    public string? DefaultTargetPath { get; set; }
     public string? TargetPath { get; set; }
 }

--- a/IconSwapperGui/Services/DialogService.cs
+++ b/IconSwapperGui/Services/DialogService.cs
@@ -1,5 +1,5 @@
 ﻿using System.Windows;
-using IconSwapperGui.Interfaces;
+using IconSwapperGui.Services.Interfaces;
 
 namespace IconSwapperGui.Services;
 

--- a/IconSwapperGui/Services/ElevationService.cs
+++ b/IconSwapperGui/Services/ElevationService.cs
@@ -1,7 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Security.Principal;
 using System.Windows;
-using IconSwapperGui.Interfaces;
+using IconSwapperGui.Services.Interfaces;
 
 namespace IconSwapperGui.Services;
 

--- a/IconSwapperGui/Services/FileSystemWatcherService.cs
+++ b/IconSwapperGui/Services/FileSystemWatcherService.cs
@@ -1,5 +1,5 @@
 using System.IO;
-using IconSwapperGui.Interfaces;
+using IconSwapperGui.Services.Interfaces;
 
 namespace IconSwapperGui.Services;
 

--- a/IconSwapperGui/Services/IconManagementService.cs
+++ b/IconSwapperGui/Services/IconManagementService.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.ObjectModel;
 using System.IO;
-using IconSwapperGui.Interfaces;
 using IconSwapperGui.Models;
+using IconSwapperGui.Services.Interfaces;
 
 namespace IconSwapperGui.Services;
 

--- a/IconSwapperGui/Services/Interfaces/IApplicationService.cs
+++ b/IconSwapperGui/Services/Interfaces/IApplicationService.cs
@@ -1,6 +1,6 @@
 ﻿using IconSwapperGui.Models;
 
-namespace IconSwapperGui.Interfaces;
+namespace IconSwapperGui.Services.Interfaces;
 
 public interface IApplicationService
 {

--- a/IconSwapperGui/Services/Interfaces/IDialogService.cs
+++ b/IconSwapperGui/Services/Interfaces/IDialogService.cs
@@ -1,4 +1,4 @@
-﻿namespace IconSwapperGui.Interfaces;
+﻿namespace IconSwapperGui.Services.Interfaces;
 
 public interface IDialogService
 {

--- a/IconSwapperGui/Services/Interfaces/IElevationService.cs
+++ b/IconSwapperGui/Services/Interfaces/IElevationService.cs
@@ -1,4 +1,4 @@
-﻿namespace IconSwapperGui.Interfaces;
+﻿namespace IconSwapperGui.Services.Interfaces;
 
 public interface IElevationService
 {

--- a/IconSwapperGui/Services/Interfaces/IFileSystemWatcherService.cs
+++ b/IconSwapperGui/Services/Interfaces/IFileSystemWatcherService.cs
@@ -1,4 +1,4 @@
-namespace IconSwapperGui.Interfaces;
+namespace IconSwapperGui.Services.Interfaces;
 
 public interface IFileSystemWatcherService : IDisposable
 {

--- a/IconSwapperGui/Services/Interfaces/IIconManagementService.cs
+++ b/IconSwapperGui/Services/Interfaces/IIconManagementService.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.ObjectModel;
 using IconSwapperGui.Models;
 
-namespace IconSwapperGui.Interfaces;
+namespace IconSwapperGui.Services.Interfaces;
 
 public interface IIconManagementService
 {

--- a/IconSwapperGui/Services/Interfaces/ISettingsService.cs
+++ b/IconSwapperGui/Services/Interfaces/ISettingsService.cs
@@ -1,6 +1,6 @@
 ﻿using IconSwapperGui.Models;
 
-namespace IconSwapperGui.Interfaces;
+namespace IconSwapperGui.Services.Interfaces;
 
 public interface ISettingsService
 {

--- a/IconSwapperGui/Services/SettingsService.cs
+++ b/IconSwapperGui/Services/SettingsService.cs
@@ -1,7 +1,7 @@
 ﻿using System.IO;
 using System.Text.Json;
-using IconSwapperGui.Interfaces;
 using IconSwapperGui.Models;
+using IconSwapperGui.Services.Interfaces;
 using Newtonsoft.Json.Linq;
 
 namespace IconSwapperGui.Services;

--- a/IconSwapperGui/UserControls/SwapperUserControl.xaml
+++ b/IconSwapperGui/UserControls/SwapperUserControl.xaml
@@ -79,6 +79,13 @@
                             </StackPanel>
                         </DataTemplate>
                     </ListBox.ItemTemplate>
+
+                    <ListBox.ContextMenu>
+                        <ContextMenu>
+                            <MenuItem Header="Reset Icon"
+                                      Command="{Binding ResetIconContextCommand}" />
+                        </ContextMenu>
+                    </ListBox.ContextMenu>
                 </ListBox>
             </StackPanel>
         </materialDesign:Card>

--- a/IconSwapperGui/ViewModels/ConverterViewModel.cs
+++ b/IconSwapperGui/ViewModels/ConverterViewModel.cs
@@ -4,9 +4,10 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using IconSwapperGui.Commands;
 using IconSwapperGui.Commands.Converter;
 using IconSwapperGui.Commands.Swapper;
-using IconSwapperGui.Interfaces;
 using IconSwapperGui.Models;
 using IconSwapperGui.Services;
+using IconSwapperGui.Services.Interfaces;
+using IconSwapperGui.ViewModels.Interfaces;
 
 namespace IconSwapperGui.ViewModels;
 

--- a/IconSwapperGui/ViewModels/Interfaces/IIconViewModel.cs
+++ b/IconSwapperGui/ViewModels/Interfaces/IIconViewModel.cs
@@ -1,7 +1,8 @@
 using System.Collections.ObjectModel;
 using IconSwapperGui.Models;
+using IconSwapperGui.Services.Interfaces;
 
-namespace IconSwapperGui.Interfaces;
+namespace IconSwapperGui.ViewModels.Interfaces;
 
 public interface IIconViewModel
 {

--- a/IconSwapperGui/ViewModels/SettingsViewModel.cs
+++ b/IconSwapperGui/ViewModels/SettingsViewModel.cs
@@ -2,7 +2,7 @@ using System.IO;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using IconSwapperGui.Commands;
-using IconSwapperGui.Interfaces;
+using IconSwapperGui.Services.Interfaces;
 using Microsoft.Win32;
 using Application = System.Windows.Application;
 

--- a/IconSwapperGui/ViewModels/SwapperViewModel.cs
+++ b/IconSwapperGui/ViewModels/SwapperViewModel.cs
@@ -4,9 +4,10 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using IconSwapperGui.Commands;
 using IconSwapperGui.Commands.Swapper;
 using IconSwapperGui.Commands.Swapper.ContextMenu;
-using IconSwapperGui.Interfaces;
 using IconSwapperGui.Models;
 using IconSwapperGui.Services;
+using IconSwapperGui.Services.Interfaces;
+using IconSwapperGui.ViewModels.Interfaces;
 
 namespace IconSwapperGui.ViewModels;
 
@@ -62,6 +63,7 @@ public partial class SwapperViewModel : ObservableObject, IIconViewModel
         DeleteIconContextCommand = new DeleteIconContextCommand(this);
         DuplicateIconContextCommand = new DuplicateIconContextCommand(this);
         OpenExplorerContextCommand = new OpenExplorerContextCommand(this);
+        ResetIconContextCommand = new ResetIconContextCommand(this);
 
         LoadPreviousApplications();
         LoadPreviousIcons();
@@ -75,6 +77,7 @@ public partial class SwapperViewModel : ObservableObject, IIconViewModel
     public RelayCommand DeleteIconContextCommand { get; }
     public RelayCommand DuplicateIconContextCommand { get; }
     public RelayCommand OpenExplorerContextCommand { get; }
+    public RelayCommand ResetIconContextCommand { get; }
 
     public ISettingsService SettingsService { get; set; }
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Welcome to IconSwapperGui, your all-in-one solution for changing shortcut icons 
   - Have a dedicated folder for all your icons? We got you covered!
 - Change Icons of Shortcuts
   - Currently supports .url and .lnk shortcut types.
-  - Right click on any icon. giving you options of opening it in Windows Explorer, copying the path, duplicating or deleting the icon!
+  - Right click on any icon, giving you options of opening it in Windows Explorer, copying the path, duplicating or deleting the icon!
+- Reset Shortcuts To Default Icons
+  - Right click on any shortcut, allowing you to reset an icon automatically or manually as a fallback.
 - Search Functionality
   - Have a specific icon in mind for your chosen shortcut? Use the search bar and easily filter through your icons!
 - Auto-Refresh

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "LatestVersion": "1.8.0"
+  "LatestVersion": "1.8.1"
 }


### PR DESCRIPTION
This PR adds a new feature that allows the user to reset a shortcut icon back to it's default icon.

If the shortcut is linked to a .exe file, the icon will be automatically reset, but will fall back to a manual mode for any other links, such as Steam shortcuts, which will open a dialog box in the directory of where Steam stores the games icons.