### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Build and Release
 
 on:
@@ -50,6 +52,8 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: build
     if: github.ref == 'refs/heads/main'
 


### PR DESCRIPTION
Potential fix for [https://github.com/aj-phillips/IconSwapperGui/security/code-scanning/2](https://github.com/aj-phillips/IconSwapperGui/security/code-scanning/2)

To fix the problem, you should add a `permissions` block specifying the least required privileges. The workflow has two jobs: `build` and `release`. The `build` job does not require write access to repository contents: only code checkout, build, and artifact upload are performed, so `contents: read` suffices. The `release` job creates a GitHub Release via `softprops/action-gh-release@v2`, which requires `contents: write` permission. The best fix is to add a top-level `permissions:` block with `contents: read` (so all jobs get minimal permissions), and then add a per-job `permissions:` block for the `release` job granting `contents: write`. Edit `.github/workflows/release.yml` as follows:

- At the top (after the `name:` block), add:
    ```yaml
    permissions:
      contents: read
    ```
- In the `release` job, add:
    ```yaml
    permissions:
      contents: write
    ```
right below `runs-on: ubuntu-latest`.

No further imports or code changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
