### PR TITLE
Enhance export workflow with new dialog and refactoring

### DIFF
--- a/IconSwapperGui/Commands/PixelArtEditor/ExportIconCommand.cs
+++ b/IconSwapperGui/Commands/PixelArtEditor/ExportIconCommand.cs
@@ -26,15 +26,23 @@ public class ExportIconCommand : RelayCommand
 
     public override void Execute(object? parameter)
     {
-        var folderPath = OpenFolderDialog();
-        if (string.IsNullOrEmpty(folderPath)) return;
+        var defaultName = string.IsNullOrWhiteSpace(_viewModel.IconName) ? "Pixel_Art" : _viewModel.IconName;
+        var dlg = new Windows.ExportDialogWindow(defaultName) { Owner = System.Windows.Application.Current.MainWindow };
+        var res = dlg.ShowDialog();
+        if (res != true) return;
+
+        var folderPath = dlg.FolderPath;
+        var fileName = dlg.FileName?.Trim();
+        if (string.IsNullOrEmpty(folderPath) || string.IsNullOrEmpty(fileName)) return;
+
+        _viewModel.IconName = fileName;
 
         CanvasHelper.GetDpi(_viewModel.DrawableCanvas, out _canvasDpiX, out _canvasDpiY);
 
-        var pngPath = SaveCanvasAsPngForExport(folderPath);
+        var pngPath = SaveCanvasAsPngForExportTo(folderPath, fileName);
         if (string.IsNullOrEmpty(pngPath)) return;
 
-        CreateAndSaveIcon(pngPath, folderPath);
+        CreateAndSaveIconFromPng(pngPath, folderPath, fileName);
 
         DeleteTemporaryFile(pngPath);
     }
@@ -44,6 +52,68 @@ public class ExportIconCommand : RelayCommand
         var openFolderDialog = new OpenFolderDialog();
 
         return openFolderDialog.ShowDialog() == true ? openFolderDialog.FolderName : string.Empty;
+    }
+
+    private string SaveCanvasAsPngForExportTo(string folderPath, string baseFileName)
+    {
+        if (_viewModel.DrawableCanvas == null) return string.Empty;
+
+        var exportCanvas = new Canvas
+        {
+            Width = _viewModel.DrawableCanvas.ActualWidth,
+            Height = _viewModel.DrawableCanvas.ActualHeight,
+            Background = new SolidColorBrush(_viewModel.BackgroundColor)
+        };
+
+        foreach (var pixelRect in _viewModel.Pixels)
+        {
+            var exportRect = new Rectangle
+            {
+                Width = pixelRect.Width,
+                Height = pixelRect.Height,
+                Fill = pixelRect.Fill,
+                Stroke = pixelRect.Stroke,
+                StrokeThickness = 0
+            };
+
+            Canvas.SetLeft(exportRect, Canvas.GetLeft(pixelRect));
+            Canvas.SetTop(exportRect, Canvas.GetTop(pixelRect));
+
+            exportCanvas.Children.Add(exportRect);
+        }
+
+        return SaveCanvasAsPngWithName(exportCanvas, folderPath, baseFileName);
+    }
+
+    private string SaveCanvasAsPngWithName(FrameworkElement canvas, string folderPath, string baseFileName)
+    {
+        var width = (int)canvas.Width;
+        var height = (int)canvas.Height;
+
+        var renderBitmap = new RenderTargetBitmap(width, height, _canvasDpiX, _canvasDpiY, PixelFormats.Pbgra32);
+
+        canvas.Measure(new Size(width, height));
+        canvas.Arrange(new Rect(new Size(width, height)));
+        renderBitmap.Render(canvas);
+
+        var safeBase = GetSafeBaseNameFor(baseFileName);
+        var pngPath = Path.Combine(folderPath, $"{safeBase}.png");
+
+        try
+        {
+            using var fileStream = new FileStream(pngPath, FileMode.Create);
+            var encoder = new PngBitmapEncoder();
+
+            encoder.Frames.Add(BitmapFrame.Create(renderBitmap));
+
+            encoder.Save(fileStream);
+        }
+        catch (Exception)
+        {
+            return string.Empty;
+        }
+
+        return pngPath;
     }
 
     private string SaveCanvasAsPngForExport(string folderPath)
@@ -88,7 +158,8 @@ public class ExportIconCommand : RelayCommand
         canvas.Arrange(new Rect(new Size(width, height)));
         renderBitmap.Render(canvas);
 
-        var pngPath = Path.Combine(folderPath, $"Full_Canvas_{DateTime.UtcNow:yyyyMMdd_HHmmss}.png");
+        var baseName = GetSafeBaseName();
+        var pngPath = Path.Combine(folderPath, $"{baseName}_{DateTime.UtcNow:yyyyMMdd_HHmmss}.png");
 
         try
         {
@@ -107,7 +178,7 @@ public class ExportIconCommand : RelayCommand
         return pngPath;
     }
 
-    private void CreateAndSaveIcon(string pngPath, string folderPath)
+    private void CreateAndSaveIconFromPng(string pngPath, string folderPath, string baseFileName)
     {
         using var image = new MagickImage(pngPath);
         image.Alpha(AlphaOption.On);
@@ -122,9 +193,40 @@ public class ExportIconCommand : RelayCommand
 
         finalImage.Composite(image, offsetX, offsetY, CompositeOperator.Over);
 
-        var icoPath = Path.Combine(folderPath, $"Pixel_Art_{DateTime.UtcNow:yyyyMMdd_HHmmss}.ico");
+        var safeBase = GetSafeBaseNameFor(baseFileName);
+        var icoPath = Path.Combine(folderPath, $"{safeBase}.ico");
         finalImage.Format = MagickFormat.Icon;
         finalImage.Write(icoPath);
+    }
+
+    private static string GetSafeBaseNameFor(string name)
+    {
+        var baseName = name ?? string.Empty;
+        baseName = baseName.Trim();
+        if (string.IsNullOrEmpty(baseName)) baseName = "Pixel_Art";
+
+        baseName = Path.GetInvalidFileNameChars().Aggregate(baseName, (current, c) => current.Replace(c, '_'));
+
+        while (baseName.Contains("__")) baseName = baseName.Replace("__", "_");
+
+        return baseName;
+    }
+
+    private string GetSafeBaseName()
+    {
+        var name = _viewModel.IconName ?? string.Empty;
+        name = name.Trim();
+        if (string.IsNullOrEmpty(name)) name = "Pixel_Art";
+
+        foreach (var c in Path.GetInvalidFileNameChars())
+        {
+            name = name.Replace(c, '_');
+        }
+
+        // Collapse multiple underscores
+        while (name.Contains("__")) name = name.Replace("__", "_");
+
+        return name;
     }
 
     private static void DeleteTemporaryFile(string filePath)

--- a/IconSwapperGui/Models/Settings.cs
+++ b/IconSwapperGui/Models/Settings.cs
@@ -2,6 +2,7 @@
 
 public class Settings
 {
+    public string? ExportLocation { get; set; }
     public string? IconLocation { get; set; }
     public string? ConverterIconLocation { get; set; }
     public string? ApplicationsLocation { get; set; }

--- a/IconSwapperGui/Services/Interfaces/ISettingsService.cs
+++ b/IconSwapperGui/Services/Interfaces/ISettingsService.cs
@@ -8,6 +8,7 @@ public interface ISettingsService
     T? GetSettingsFieldValue<T>(string fieldName);
     void SaveIconsLocation(string? iconsPath);
     void SaveConverterIconsLocation(string? iconsPath);
+    void SaveExportLocation(string? exportPath);
     void SaveApplicationsLocation(string? applicationsPath);
     void SaveEnableDarkMode(bool? enableDarkMode);
     void SaveEnableLaunchAtStartup(bool? enableLaunchAtStartup);

--- a/IconSwapperGui/Services/SettingsService.cs
+++ b/IconSwapperGui/Services/SettingsService.cs
@@ -81,6 +81,12 @@ public class SettingsService : ISettingsService
         UpdateSettingsProperty((settings, value) => settings.IconLocation = value, iconsPath);
     }
 
+    public void SaveExportLocation(string? exportPath)
+    {
+        _logger.Information("Saving export location: {ExportPath}", exportPath ?? "null");
+        UpdateSettingsProperty((settings, value) => settings.ExportLocation = value, exportPath);
+    }
+
     public void SaveConverterIconsLocation(string? iconsPath)
     {
         _logger.Information("Saving converter icons location: {IconsPath}", iconsPath ?? "null");
@@ -164,6 +170,13 @@ public class SettingsService : ISettingsService
         return location;
     }
 
+    public string? GetExportLocation()
+    {
+        var location = GetSettingsFieldValue<string>("ExportLocation");
+        _logger.Information("Retrieved export location: {Location}", location ?? "null");
+        return location;
+    }
+
     public bool? GetAutoUpdateValue()
     {
         var value = GetSettingsFieldValue<bool>("EnableAutoUpdate");
@@ -202,6 +215,7 @@ public class SettingsService : ISettingsService
 
         return new Settings
         {
+            ExportLocation = "",
             IconLocation = "",
             ConverterIconLocation = "",
             ApplicationsLocation = "",

--- a/IconSwapperGui/UserControls/PixelArtEditorUserControl.xaml
+++ b/IconSwapperGui/UserControls/PixelArtEditorUserControl.xaml
@@ -102,7 +102,8 @@
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="10">
                     <StackPanel Orientation="Vertical">
                         <Button
-                            Command="{Binding ExportIconCommand}"
+                            x:Name="ExportButton"
+                            Click="ExportButton_Click"
                             Margin="10"
                             Style="{StaticResource MaterialDesignRaisedDarkButton}">
                             <Grid>

--- a/IconSwapperGui/UserControls/PixelArtEditorUserControl.xaml.cs
+++ b/IconSwapperGui/UserControls/PixelArtEditorUserControl.xaml.cs
@@ -52,4 +52,12 @@ public partial class PixelArtEditorUserControl
         if (_viewModel?.ZoomSliderValueChangedCommand != null)
             HandleEvent(e, _viewModel.ZoomSliderValueChangedCommand);
     }
+
+    private void ExportButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (_viewModel?.ExportIconCommand != null && _viewModel.ExportIconCommand.CanExecute(null))
+        {
+            _viewModel.ExportIconCommand.Execute(null);
+        }
+    }
 }

--- a/IconSwapperGui/ViewModels/PixelArtEditorViewModel.cs
+++ b/IconSwapperGui/ViewModels/PixelArtEditorViewModel.cs
@@ -26,6 +26,8 @@ public partial class PixelArtEditorViewModel : ObservableObject
     [ObservableProperty] private Color _selectedColor = Colors.Black;
 
     [ObservableProperty] private double _zoomLevel = 1.0;
+    
+    [ObservableProperty] private string _iconName = "Pixel_Art";
 
     public PixelArtEditorViewModel()
     {

--- a/IconSwapperGui/Windows/ExportDialogWindow.xaml
+++ b/IconSwapperGui/Windows/ExportDialogWindow.xaml
@@ -1,0 +1,75 @@
+<Window x:Class="IconSwapperGui.Windows.ExportDialogWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+        mc:Ignorable="d"
+        Title="Export Icon"
+        Width="480"
+        MinWidth="420"
+        SizeToContent="Height"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize">
+
+	<StackPanel Margin="16">
+		<!-- Title -->
+		<TextBlock x:Name="PromptText"
+                   Text="Export Pixel Art"
+                   FontSize="16"
+                   FontWeight="Bold"
+                   Margin="0,0,0,12"
+                   Foreground="Black"/>
+
+		<!-- File name -->
+		<StackPanel Orientation="Vertical" Margin="0,0,0,12">
+			<TextBlock Text="File name" Margin="0,0,0,4" Foreground="Black"/>
+			<TextBox x:Name="NameTextBox"
+                     MinHeight="36"
+                     Style="{StaticResource MaterialDesignOutlinedTextBox}"/>
+		</StackPanel>
+
+		<!-- Export path -->
+		<Grid Margin="0,0,0,12">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="Auto"/>
+				<ColumnDefinition Width="*"/>
+				<ColumnDefinition Width="Auto"/>
+			</Grid.ColumnDefinitions>
+
+			<TextBlock Grid.Column="0"
+                       Text="Export to:"
+                       VerticalAlignment="Center"
+                       Margin="0,0,8,0"
+                       Foreground="Black"/>
+
+			<TextBlock x:Name="FolderText"
+                       Grid.Column="1"
+                       VerticalAlignment="Center"
+                       Text="(no folder selected)"
+                       TextTrimming="CharacterEllipsis"
+                       Foreground="Black"/>
+
+			<Button x:Name="BrowseButton"
+                    Grid.Column="2"
+                    Content="Browse..."
+                    Margin="8,0,0,0"
+                    Padding="12,4"
+                    Click="BrowseButton_Click"/>
+		</Grid>
+
+		<!-- Bottom buttons -->
+		<StackPanel Orientation="Horizontal"
+                    HorizontalAlignment="Right">
+			<Button x:Name="CancelButton"
+                    Content="Cancel"
+                    Width="80"
+                    Margin="0,0,8,0"
+                    Click="CancelButton_Click"/>
+			<Button x:Name="OkButton"
+                    Content="Export"
+                    Width="80"
+                    Click="OkButton_Click"/>
+		</StackPanel>
+	</StackPanel>
+</Window>

--- a/IconSwapperGui/Windows/ExportDialogWindow.xaml.cs
+++ b/IconSwapperGui/Windows/ExportDialogWindow.xaml.cs
@@ -1,0 +1,84 @@
+using Microsoft.WindowsAPICodePack.Dialogs;
+using System.IO;
+using System.Windows;
+using IconSwapperGui.Services;
+
+namespace IconSwapperGui.Windows;
+
+public partial class ExportDialogWindow : Window
+{
+    public string? FileName { get; private set; }
+    public string? FolderPath { get; private set; }
+
+    private readonly SettingsService _settingsService;
+
+    public ExportDialogWindow(string defaultName = "Pixel_Art")
+    {
+        InitializeComponent();
+
+        _settingsService = new SettingsService();
+
+        NameTextBox.Text = defaultName;
+        NameTextBox.SelectAll();
+        NameTextBox.Focus();
+
+        var saved = _settingsService.GetExportLocation();
+        if (!string.IsNullOrWhiteSpace(saved) && Directory.Exists(saved))
+        {
+            FolderPath = saved;
+            FolderText.Text = FolderPath;
+        }
+    }
+
+    private void BrowseButton_Click(object sender, RoutedEventArgs e)
+    {
+        var dlg = new CommonOpenFileDialog { IsFolderPicker = true };
+        if (dlg.ShowDialog() != CommonFileDialogResult.Ok) return;
+        FolderPath = dlg.FileName;
+        FolderText.Text = FolderPath;
+
+        try
+        {
+            _settingsService.SaveExportLocation(FolderPath);
+        }
+        catch
+        {
+            // ignore save failures
+        }
+    }
+
+    private void OkButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(NameTextBox.Text))
+        {
+            MessageBox.Show("Please enter a file name", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(FolderPath) || !Directory.Exists(FolderPath))
+        {
+            MessageBox.Show("Please choose a valid export folder", "Validation", MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
+        }
+
+        FileName = NameTextBox.Text.Trim();
+
+        try
+        {
+            _settingsService.SaveExportLocation(FolderPath);
+        }
+        catch
+        {
+            // ignore
+        }
+
+        DialogResult = true;
+        Close();
+    }
+
+    private void CancelButton_Click(object sender, RoutedEventArgs e)
+    {
+        DialogResult = false;
+        Close();
+    }
+}


### PR DESCRIPTION
Enhance export workflow with new dialog and refactoring

Refactored the export logic in `ExportIconCommand`:
- Replaced `OpenFolderDialog` with `ExportDialogWindow` for specifying both file name and folder.
- Added `SaveCanvasAsPngForExportTo` and `SaveCanvasAsPngWithName` for saving PNGs with user-defined names.
- Updated `Execute` method to validate file name and folder path.
- Replaced `CreateAndSaveIcon` with `CreateAndSaveIconFromPng` to include file name handling.
- Introduced helper methods for sanitizing file names.

Updated `Settings` model and `SettingsService`:
- Added `ExportLocation` property to persist the last-used export folder.
- Implemented `SaveExportLocation` and `GetExportLocation` methods.

Enhanced UI and ViewModel:
- Added `ExportButton` to `PixelArtEditorUserControl` and bound it to `ExportIconCommand`.
- Introduced `IconName` property in `PixelArtEditorViewModel` for default file naming.

Added `ExportDialogWindow`:
- Created a new dialog for specifying file name and folder path.
- Integrated folder browsing and validation logic.

Miscellaneous:
- Improved file name safety in PNG and ICO export logic.