### PR TITLE
Add folder icon management functionality

### DIFF
--- a/IconSwapperGui/Commands/Swapper/ChooseFoldersFolderCommand.cs
+++ b/IconSwapperGui/Commands/Swapper/ChooseFoldersFolderCommand.cs
@@ -1,0 +1,25 @@
+using IconSwapperGui.ViewModels;
+using Microsoft.WindowsAPICodePack.Dialogs;
+
+namespace IconSwapperGui.Commands.Swapper;
+
+public class ChooseFoldersFolderCommand : RelayCommand
+{
+    private readonly SwapperViewModel _viewModel;
+
+    public ChooseFoldersFolderCommand(SwapperViewModel viewModel, Action<object> execute, Func<object, bool>? canExecute = null) : base(execute, canExecute)
+    {
+        _viewModel = viewModel;
+    }
+
+    public override void Execute(object? parameter)
+    {
+        var dlg = new CommonOpenFileDialog { IsFolderPicker = true };
+        if (dlg.ShowDialog() != CommonFileDialogResult.Ok) return;
+
+        var folder = dlg.FileName;
+        _viewModel.FoldersFolderPath = folder;
+        _viewModel.PopulateFoldersList(folder);
+        _viewModel.SettingsService.SaveFoldersLocation(folder);
+    }
+}

--- a/IconSwapperGui/Commands/Swapper/SwapFolderIconCommand.cs
+++ b/IconSwapperGui/Commands/Swapper/SwapFolderIconCommand.cs
@@ -1,0 +1,52 @@
+using IconSwapperGui.ViewModels;
+using IconSwapperGui.Services.Interfaces;
+
+namespace IconSwapperGui.Commands.Swapper;
+
+public class SwapFolderIconCommand : RelayCommand
+{
+    private readonly SwapperViewModel _viewModel;
+    private readonly IFolderService _folderService;
+    private readonly IIconHistoryService? _historyService;
+
+    public SwapFolderIconCommand(SwapperViewModel viewModel, IFolderService folderService, IIconHistoryService? historyService = null, Action<object> execute = null!, Func<object, bool>? canExecute = null) : base(execute, canExecute)
+    {
+        _viewModel = viewModel;
+        _folderService = folderService ?? throw new ArgumentNullException(nameof(folderService));
+        _historyService = historyService;
+    }
+
+    public override async void Execute(object? parameter)
+    {
+        if (_viewModel.SelectedFolder == null || _viewModel.SelectedIcon == null)
+        {
+            _viewModel.DialogService.ShowWarning("Please select a folder and an icon to swap.", "No Folder or Icon Selected");
+            return;
+        }
+
+        var success = await _folderService.ChangeFolderIconAsync(_viewModel.SelectedFolder.Path, _viewModel.SelectedIcon.Path);
+
+        if (success)
+        {
+            try
+            {
+                if (_historyService != null)
+                {
+                    await _historyService.RecordIconChangeAsync(_viewModel.SelectedFolder.Path,
+                        _viewModel.SelectedIcon.Path);
+                }
+            }
+            catch
+            {
+                // ignore
+            }
+
+            await _viewModel.ShowSuccessTick();
+            _viewModel.RefreshGui();
+        }
+        else
+        {
+            _viewModel.DialogService.ShowError("Error", "Failed to change folder icon");
+        }
+    }
+}

--- a/IconSwapperGui/Models/FolderItem.cs
+++ b/IconSwapperGui/Models/FolderItem.cs
@@ -1,0 +1,13 @@
+namespace IconSwapperGui.Models;
+
+public class FolderItem
+{
+    public FolderItem(string name, string path)
+    {
+        Name = name;
+        Path = path;
+    }
+
+    public string Name { get; set; }
+    public string Path { get; set; }
+}

--- a/IconSwapperGui/Models/Settings.cs
+++ b/IconSwapperGui/Models/Settings.cs
@@ -4,6 +4,7 @@ public class Settings
 {
     public string? ExportLocation { get; set; }
     public string? IconLocation { get; set; }
+    public string? FoldersLocation { get; set; }
     public string? ConverterIconLocation { get; set; }
     public string? ApplicationsLocation { get; set; }
     public bool? EnableDarkMode { get; set; }

--- a/IconSwapperGui/Services/FolderService.cs
+++ b/IconSwapperGui/Services/FolderService.cs
@@ -1,0 +1,169 @@
+using System.Collections.ObjectModel;
+using System.IO;
+using IconSwapperGui.Models;
+using IconSwapperGui.Services.Interfaces;
+using Serilog;
+using System.Runtime.InteropServices;
+
+namespace IconSwapperGui.Services;
+
+public class FolderService : IFolderService
+{
+    [DllImport("Shell32.dll", CharSet = CharSet.Auto)]
+    private static extern void SHChangeNotify(uint wEventId, uint uFlags, IntPtr dwItem1, IntPtr dwItem2);
+
+    private readonly ILogger _logger = Log.ForContext<FolderService>();
+
+    public ObservableCollection<FolderItem> GetFolders(string? folderPath)
+    {
+        var folders = new ObservableCollection<FolderItem>();
+
+        if (string.IsNullOrWhiteSpace(folderPath))
+        {
+            _logger.Warning("GetFolders called with null or empty path");
+            return folders;
+        }
+
+        if (!Directory.Exists(folderPath))
+        {
+            _logger.Warning("GetFolders path does not exist: {Path}", folderPath);
+            return folders;
+        }
+
+        try
+        {
+            var dirs = Directory.GetDirectories(folderPath, "*", SearchOption.TopDirectoryOnly);
+            foreach (var d in dirs)
+            {
+                folders.Add(new FolderItem(Path.GetFileName(d), d));
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "Error enumerating folders for {Path}", folderPath);
+        }
+
+        return folders;
+    }
+
+    public Task<bool> ChangeFolderIconAsync(string folderPath, string iconPath)
+    {
+        return Task.Run(() =>
+        {
+            try
+            {
+                if (!Directory.Exists(folderPath))
+                {
+                    _logger.Warning("Folder does not exist: {Path}", folderPath);
+                    return false;
+                }
+
+                if (!File.Exists(iconPath))
+                {
+                    _logger.Warning("Icon file does not exist: {IconPath}", iconPath);
+                    return false;
+                }
+
+                var iniPath = Path.Combine(folderPath, "desktop.ini");
+                var lines = new List<string>
+                {
+                    "[.ShellClassInfo]",
+                    $"IconResource={iconPath},0"
+                };
+
+                try
+                {
+                    try
+                    {
+                        var dirInfoForWrite = new DirectoryInfo(folderPath);
+                        dirInfoForWrite.Attributes &= ~FileAttributes.ReadOnly;
+                        dirInfoForWrite.Attributes &= ~FileAttributes.System;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.Warning(ex, "Failed to clear attributes on folder before writing desktop.ini: {Path}", folderPath);
+                    }
+
+                    if (File.Exists(iniPath))
+                    {
+                        try
+                        {
+                            File.SetAttributes(iniPath, FileAttributes.Normal);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.Warning(ex, "Failed to set desktop.ini attributes to Normal before writing: {Path}", iniPath);
+                        }
+                    }
+
+                    var wrote = false;
+                    var attempts = 0;
+                    while (!wrote && attempts < 5)
+                    {
+                        attempts++;
+                        try
+                        {
+                            File.WriteAllLines(iniPath, lines);
+                            wrote = true;
+                        }
+                        catch (UnauthorizedAccessException)
+                        {
+                            try
+                            {
+                                using var fs = new FileStream(iniPath, FileMode.Create, FileAccess.Write, FileShare.ReadWrite);
+                                using var sw = new StreamWriter(fs);
+                                foreach (var line in lines)
+                                {
+                                    sw.WriteLine(line);
+                                }
+
+                                wrote = true;
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.Warning(ex, "Attempt {Attempt} failed writing desktop.ini, will retry: {Path}", attempts, iniPath);
+                                System.Threading.Thread.Sleep(150);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.Warning(ex, "Attempt {Attempt} failed writing desktop.ini, will retry: {Path}", attempts, iniPath);
+                            System.Threading.Thread.Sleep(150);
+                        }
+                    }
+
+                    if (!wrote)
+                    {
+                        _logger.Error("Failed to write desktop.ini after multiple attempts: {Path}", iniPath);
+                        return false;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.Error(ex, "Unexpected error while preparing/writing desktop.ini: {Path}", iniPath);
+                    return false;
+                }
+
+                var dirInfo = new DirectoryInfo(folderPath);
+                dirInfo.Attributes |= FileAttributes.ReadOnly | FileAttributes.System;
+
+                var fi = new FileInfo(iniPath);
+                fi.Attributes |= FileAttributes.Hidden | FileAttributes.System;
+
+                try
+                {
+                    SHChangeNotify(0x08000000, 0x0000, IntPtr.Zero, IntPtr.Zero);
+                }
+                catch { }
+
+                _logger.Information("Folder icon changed for {Path} to {Icon}", folderPath, iconPath);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Failed to change folder icon for {Path}", folderPath);
+                return false;
+            }
+        });
+    }
+}

--- a/IconSwapperGui/Services/Interfaces/IFolderService.cs
+++ b/IconSwapperGui/Services/Interfaces/IFolderService.cs
@@ -1,0 +1,10 @@
+using System.Collections.ObjectModel;
+using IconSwapperGui.Models;
+
+namespace IconSwapperGui.Services.Interfaces;
+
+public interface IFolderService
+{
+    ObservableCollection<FolderItem> GetFolders(string? folderPath);
+    Task<bool> ChangeFolderIconAsync(string folderPath, string iconPath);
+}

--- a/IconSwapperGui/Services/Interfaces/ISettingsService.cs
+++ b/IconSwapperGui/Services/Interfaces/ISettingsService.cs
@@ -8,6 +8,7 @@ public interface ISettingsService
     T? GetSettingsFieldValue<T>(string fieldName);
     void SaveIconsLocation(string? iconsPath);
     void SaveConverterIconsLocation(string? iconsPath);
+    void SaveFoldersLocation(string? foldersPath);
     void SaveExportLocation(string? exportPath);
     void SaveApplicationsLocation(string? applicationsPath);
     void SaveEnableDarkMode(bool? enableDarkMode);
@@ -17,6 +18,7 @@ public interface ISettingsService
     string? GetApplicationsLocation();
     string? GetIconsLocation();
     string? GetConverterIconsLocation();
+    string? GetFoldersLocation();
     bool? GetAutoUpdateValue();
     bool? GetSeasonalEffectsValue();
 }

--- a/IconSwapperGui/Services/SettingsService.cs
+++ b/IconSwapperGui/Services/SettingsService.cs
@@ -93,6 +93,12 @@ public class SettingsService : ISettingsService
         UpdateSettingsProperty((settings, value) => settings.ConverterIconLocation = value, iconsPath);
     }
 
+    public void SaveFoldersLocation(string? foldersPath)
+    {
+        _logger.Information("Saving folders location: {FoldersPath}", foldersPath ?? "null");
+        UpdateSettingsProperty((settings, value) => settings.FoldersLocation = value, foldersPath);
+    }
+
     public void SaveApplicationsLocation(string? applicationsPath)
     {
         _logger.Information("Saving applications location: {ApplicationsPath}", applicationsPath ?? "null");
@@ -170,6 +176,13 @@ public class SettingsService : ISettingsService
         return location;
     }
 
+    public string? GetFoldersLocation()
+    {
+        var location = GetSettingsFieldValue<string>("FoldersLocation");
+        _logger.Information("Retrieved folders location: {Location}", location ?? "null");
+        return location;
+    }
+
     public string? GetExportLocation()
     {
         var location = GetSettingsFieldValue<string>("ExportLocation");
@@ -217,6 +230,7 @@ public class SettingsService : ISettingsService
         {
             ExportLocation = "",
             IconLocation = "",
+            FoldersLocation = "",
             ConverterIconLocation = "",
             ApplicationsLocation = "",
             EnableDarkMode = false,

--- a/IconSwapperGui/UserControls/SwapperUserControl.xaml
+++ b/IconSwapperGui/UserControls/SwapperUserControl.xaml
@@ -10,6 +10,7 @@
     <UserControl.Resources>
         <utilities:IconPathToImageConverter x:Key="IconPathToImageConverter" />
         <utilities:ApplicationPathToImageConverter x:Key="ApplicationPathToImageConverter" />
+        <utilities:InverseBooleanToVisibilityConverter x:Key="InverseBooleanToVisibilityConverter" />
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     </UserControl.Resources>
 
@@ -18,196 +19,214 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="2*" />
-            <ColumnDefinition Width="5*" />
-        </Grid.ColumnDefinitions>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2*" />
+                <ColumnDefinition Width="5*" />
+            </Grid.ColumnDefinitions>
 
-        <materialDesign:Card Grid.Row="0" Grid.Column="0" Margin="10" materialDesign:ElevationAssist.Elevation="Dp3">
-            <StackPanel>
-                <TextBlock Text="Applications"
-                           FontSize="16"
-                           Margin="10,10,10,5"
-                           HorizontalAlignment="Center"
-                           Style="{DynamicResource MaterialDesignHeadline6TextBlockStyle}" />
-                <Button Name="ChooseApplicationShortcutFolderButton"
-                        Command="{Binding ChooseApplicationShortcutFolderCommand}"
-                        Margin="10"
-                        Style="{StaticResource MaterialDesignRaisedDarkButton}">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
-                        <materialDesign:PackIcon Kind="Folder" Grid.Column="0" VerticalAlignment="Center"
-                                                 Margin="0,0,5,0" />
-                        <TextBlock Text="Choose Shortcut Folder" Grid.Column="1" VerticalAlignment="Center"
-                                   HorizontalAlignment="Center" Foreground="White" />
-                    </Grid>
-                </Button>
-                <ListBox Name="ApplicationsListBox"
-                         ItemsSource="{Binding Applications}"
-                         SelectedItem="{Binding SelectedApplication, Mode=TwoWay}"
-                         Margin="10"
-                         ScrollViewer.VerticalScrollBarVisibility="Auto"
-                         Height="300">
-                    <ListBox.Resources>
-                        <Style TargetType="ListBoxItem">
-                            <Setter Property="Background" Value="Transparent" />
-                            <Setter Property="Padding" Value="10" />
-                            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                            <Style.Triggers>
-                                <Trigger Property="IsSelected" Value="True">
-                                    <Setter Property="Background"
-                                            Value="{DynamicResource MaterialDesignSelectionColor}" />
-                                    <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}" />
-                                </Trigger>
-                            </Style.Triggers>
-                        </Style>
-                    </ListBox.Resources>
-                    <ListBox.ItemTemplate>
-                        <DataTemplate>
-                            <StackPanel Orientation="Horizontal" ToolTip="{Binding Name}">
-                                <Image
-                                    Source="{Binding TargetPath, Converter={StaticResource IconPathToImageConverter}}"
-                                    Width="30" Height="30" Margin="5" />
-                                <TextBlock Text="{Binding Name}"
-                                           VerticalAlignment="Center"
-                                           FontSize="14"
-                                           TextTrimming="CharacterEllipsis"
-                                           MaxWidth="150" />
-                            </StackPanel>
-                        </DataTemplate>
-                    </ListBox.ItemTemplate>
-
-                    <ListBox.ContextMenu>
-                        <ContextMenu>
-                            <MenuItem Header="Manage Icon Versions"
-                                      Command="{Binding ManageVersionsContextCommand}" />
-                        </ContextMenu>
-                    </ListBox.ContextMenu>
-                </ListBox>
-            </StackPanel>
-        </materialDesign:Card>
-
-        <materialDesign:Card Grid.Row="0" Grid.Column="1" Margin="10" materialDesign:ElevationAssist.Elevation="Dp3">
-            <StackPanel>
-                <TextBlock Text="Icons"
-                           FontSize="16"
-                           Margin="10,10,10,5"
-                           HorizontalAlignment="Center"
-                           Style="{DynamicResource MaterialDesignHeadline6TextBlockStyle}" />
-                <Grid Margin="22,10,22,0">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
-                    <TextBox Width="250" Name="SearchTextBox" VerticalContentAlignment="Center"
-                             materialDesign:HintAssist.Hint="Search"
-                             Text="{Binding FilterString, UpdateSourceTrigger=PropertyChanged}" Height="45"
-                             Style="{StaticResource MaterialDesignOutlinedTextBox}" Grid.Column="0"
-                             HorizontalAlignment="Left" Margin="0,0,10,0" />
-
-                    <Button Name="ChooseIconFolderButton"
-                            Command="{Binding ChooseIconFolderCommand}"
-                            Style="{StaticResource MaterialDesignRaisedDarkButton}" Grid.Column="1">
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <materialDesign:PackIcon Kind="Folder" Grid.Column="0" VerticalAlignment="Center"
-                                                     Margin="0,0,5,0" />
-                            <TextBlock Text="Choose Icon Folder" Grid.Column="1" VerticalAlignment="Center"
-                                       HorizontalAlignment="Center" Foreground="White" />
-                        </Grid>
-                    </Button>
-                </Grid>
-                <ListBox Name="IconsListBox"
-                         ItemsSource="{Binding FilteredIcons}"
-                         SelectedItem="{Binding SelectedIcon, Mode=TwoWay}"
-                         Margin="15"
-                         HorizontalAlignment="Center"
-                         ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                         ScrollViewer.VerticalScrollBarVisibility="Auto"
-                         Height="300">
-
-                    <ListBox.Resources>
-                        <Style TargetType="ListBoxItem">
-                            <Setter Property="Background" Value="Transparent" />
-                            <Setter Property="Padding" Value="10" />
-                            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                            <Setter Property="VerticalContentAlignment" Value="Stretch" />
-                            <Style.Triggers>
-                                <Trigger Property="IsSelected" Value="True">
-                                    <Setter Property="Background"
-                                            Value="{DynamicResource MaterialDesignSelectionColor}" />
-                                    <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}" />
-                                </Trigger>
-                            </Style.Triggers>
-                        </Style>
-                    </ListBox.Resources>
-
-                    <ListBox.ItemTemplate>
-                        <DataTemplate>
-                            <Border HorizontalAlignment="Center" VerticalAlignment="Center" Width="100" Height="100">
-                                <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="Auto" />
-                                        <RowDefinition Height="Auto" />
-                                    </Grid.RowDefinitions>
-                                    <Image
-                                        Source="{Binding Path, Converter={StaticResource ApplicationPathToImageConverter}}"
-                                        Width="60" Height="60" Stretch="Uniform"
-                                        HorizontalAlignment="Center" VerticalAlignment="Center" />
-                                    <TextBlock Text="{Binding Name}"
-                                               Grid.Row="1"
-                                               TextAlignment="Center"
-                                               HorizontalAlignment="Center"
-                                               VerticalAlignment="Center"
-                                               TextTrimming="CharacterEllipsis"
-                                               ToolTip="{Binding Name}"
-                                               MaxWidth="75" />
+            <materialDesign:Card Grid.Column="0" Margin="10" materialDesign:ElevationAssist.Elevation="Dp3">
+                <TabControl SelectedIndex="{Binding LeftTabIndex, Mode=TwoWay}">
+                    <TabItem Header="Shortcuts">
+                        <StackPanel>
+                            <Button Name="ChooseApplicationShortcutFolderButton"
+                                    Command="{Binding ChooseApplicationShortcutFolderCommand}"
+                                    Margin="10"
+                                    Style="{StaticResource MaterialDesignRaisedDarkButton}">
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <materialDesign:PackIcon Kind="Folder" Grid.Column="0" VerticalAlignment="Center"
+                                                             Margin="0,0,5,0" />
+                                    <TextBlock Text="Choose Shortcut Folder" Grid.Column="1" VerticalAlignment="Center"
+                                               HorizontalAlignment="Center" Foreground="White" />
                                 </Grid>
-                            </Border>
-                        </DataTemplate>
-                    </ListBox.ItemTemplate>
+                            </Button>
+                            <ListBox Name="ApplicationsListBox"
+                                     ItemsSource="{Binding Applications}"
+                                     SelectedItem="{Binding SelectedApplication, Mode=TwoWay}"
+                                     Margin="10"
+                                     ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                     Height="300">
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Orientation="Horizontal" ToolTip="{Binding Name}">
+                                            <Image
+                                                Source="{Binding TargetPath, Converter={StaticResource IconPathToImageConverter}}"
+                                                Width="30" Height="30" Margin="5" />
+                                            <TextBlock Text="{Binding Name}"
+                                                       VerticalAlignment="Center"
+                                                       FontSize="14"
+                                                       TextTrimming="CharacterEllipsis"
+                                                       MaxWidth="150" />
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                                <ListBox.ContextMenu>
+                                    <ContextMenu>
+                                        <MenuItem Header="Manage Icon Versions"
+                                                  Command="{Binding ManageVersionsContextCommand}" />
+                                    </ContextMenu>
+                                </ListBox.ContextMenu>
+                            </ListBox>
+                        </StackPanel>
+                    </TabItem>
 
-                    <ListBox.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <WrapPanel HorizontalAlignment="Center" ItemHeight="100" ItemWidth="100" />
-                        </ItemsPanelTemplate>
-                    </ListBox.ItemsPanel>
+                    <TabItem Header="Folders">
+                        <StackPanel>
+                            <Button Name="ChooseFoldersFolderButton"
+                                    Command="{Binding ChooseFoldersFolderCommand}"
+                                    Margin="10"
+                                    Style="{StaticResource MaterialDesignRaisedDarkButton}">
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <materialDesign:PackIcon Kind="Folder" Grid.Column="0" VerticalAlignment="Center"
+                                                             Margin="0,0,5,0" />
+                                    <TextBlock Text="Choose Folder Root" Grid.Column="1" VerticalAlignment="Center"
+                                               HorizontalAlignment="Center" Foreground="White" />
+                                </Grid>
+                            </Button>
+                            <ListBox ItemsSource="{Binding Folders}"
+                                     SelectedItem="{Binding SelectedFolder, Mode=TwoWay}"
+                                     Margin="10"
+                                     Height="300">
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Orientation="Horizontal" ToolTip="{Binding Name}">
+                                            <materialDesign:PackIcon Kind="Folder" Width="26" Height="26" Margin="4" />
+                                            <TextBlock Text="{Binding Name}" VerticalAlignment="Center" />
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+                        </StackPanel>
+                    </TabItem>
+                </TabControl>
+            </materialDesign:Card>
 
-                    <ListBox.ContextMenu>
-                        <ContextMenu>
-                            <MenuItem Header="Open in Explorer"
-                                      Command="{Binding OpenExplorerContextCommand}" />
-                            <MenuItem Header="Copy Path"
-                                      Command="{Binding CopyPathContextCommand}" />
-                            <Separator />
-                            <MenuItem Header="Duplicate"
-                                      Command="{Binding DuplicateIconContextCommand}" />
-                            <Separator />
-                            <MenuItem Header="Delete"
-                                      Command="{Binding DeleteIconContextCommand}" />
-                        </ContextMenu>
-                    </ListBox.ContextMenu>
-                </ListBox>
-            </StackPanel>
-        </materialDesign:Card>
+            <materialDesign:Card Grid.Column="1" Margin="10" materialDesign:ElevationAssist.Elevation="Dp3">
+                <StackPanel>
+                    <TextBlock Text="Icons"
+                               FontSize="16"
+                               Margin="10,10,10,5"
+                               HorizontalAlignment="Center"
+                               Style="{DynamicResource MaterialDesignHeadline6TextBlockStyle}" />
+                    <Grid Margin="22,10,22,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBox Width="250" Name="SearchTextBox" VerticalContentAlignment="Center"
+                                 materialDesign:HintAssist.Hint="Search"
+                                 Text="{Binding FilterString, UpdateSourceTrigger=PropertyChanged}" Height="45"
+                                 Style="{StaticResource MaterialDesignOutlinedTextBox}" Grid.Column="0"
+                                 HorizontalAlignment="Left" Margin="0,0,10,0" />
+
+                        <Button Name="ChooseIconFolderButton"
+                                Command="{Binding ChooseIconFolderCommand}"
+                                Style="{StaticResource MaterialDesignRaisedDarkButton}" Grid.Column="1">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <materialDesign:PackIcon Kind="Folder" Grid.Column="0" VerticalAlignment="Center"
+                                                         Margin="0,0,5,0" />
+                                <TextBlock Text="Choose Icon Folder" Grid.Column="1" VerticalAlignment="Center"
+                                           HorizontalAlignment="Center" Foreground="White" />
+                            </Grid>
+                        </Button>
+                    </Grid>
+                    <ListBox Name="IconsListBox"
+                             ItemsSource="{Binding FilteredIcons}"
+                             SelectedItem="{Binding SelectedIcon, Mode=TwoWay}"
+                             Margin="15"
+                             HorizontalAlignment="Center"
+                             ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                             ScrollViewer.VerticalScrollBarVisibility="Auto"
+                             Height="300">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <Border HorizontalAlignment="Center" VerticalAlignment="Center" Width="100" Height="100">
+                                    <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                        </Grid.RowDefinitions>
+                                        <Image
+                                            Source="{Binding Path, Converter={StaticResource ApplicationPathToImageConverter}}"
+                                            Width="60" Height="60" Stretch="Uniform"
+                                            HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                        <TextBlock Text="{Binding Name}"
+                                                   Grid.Row="1"
+                                                   TextAlignment="Center"
+                                                   HorizontalAlignment="Center"
+                                                   VerticalAlignment="Center"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   ToolTip="{Binding Name}"
+                                                   MaxWidth="75" />
+                                    </Grid>
+                                </Border>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                        <ListBox.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <WrapPanel HorizontalAlignment="Center" ItemHeight="100" ItemWidth="100" />
+                            </ItemsPanelTemplate>
+                        </ListBox.ItemsPanel>
+
+                        <ListBox.ContextMenu>
+                            <ContextMenu>
+                                <MenuItem Header="Open in Explorer"
+                                          Command="{Binding OpenExplorerContextCommand}" />
+                                <MenuItem Header="Copy Path"
+                                          Command="{Binding CopyPathContextCommand}" />
+                                <Separator />
+                                <MenuItem Header="Duplicate"
+                                          Command="{Binding DuplicateIconContextCommand}" />
+                                <Separator />
+                                <MenuItem Header="Delete"
+                                          Command="{Binding DeleteIconContextCommand}" />
+                            </ContextMenu>
+                        </ListBox.ContextMenu>
+                    </ListBox>
+                </StackPanel>
+            </materialDesign:Card>
+        </Grid>
 
         <Grid Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Margin="10" HorizontalAlignment="Center">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
-            <Button Command="{Binding SwapCommand}"
+            <Button Command="{Binding DualSwapCommand}"
                     Width="140"
                     HorizontalAlignment="Center"
                     Style="{StaticResource MaterialDesignRaisedDarkButton}"
-                    IsEnabled="{Binding CanSwapIcons}">
+                    Visibility="{Binding IsFolderTabSelected, Converter={StaticResource InverseBooleanToVisibilityConverter}}">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <materialDesign:PackIcon Kind="SwapHorizontal" Grid.Column="0" VerticalAlignment="Center"
+                                             Margin="0,0,5,0" />
+                    <TextBlock Text="Swap Icon" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Center"
+                               Foreground="White" />
+                </Grid>
+            </Button>
+            <!--<Folder-specific swap button retained but hidden; main DualSwapCommand handles behavior--> 
+            <Button Visibility="{Binding IsFolderTabSelected, Converter={StaticResource BooleanToVisibilityConverter}}"
+                    Width="140"
+                    HorizontalAlignment="Center"
+                    Style="{StaticResource MaterialDesignRaisedDarkButton}"
+                    IsEnabled="{Binding CanSwapFolderIcons}"
+                    Command="{Binding SwapFolderIconCommand}">
                 <Grid>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />

--- a/IconSwapperGui/Utilities/InverseBooleanToVisibilityConverter.cs
+++ b/IconSwapperGui/Utilities/InverseBooleanToVisibilityConverter.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace IconSwapperGui.Utilities;
+
+public class InverseBooleanToVisibilityConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is bool b)
+            return b ? Visibility.Collapsed : Visibility.Visible;
+        return Visibility.Visible;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is Visibility v)
+            return v != Visibility.Visible;
+        return true;
+    }
+}


### PR DESCRIPTION
Add folder icon management functionality

Introduced functionality to manage folder icons alongside application icons. Added a new "Folders" tab in the UI for selecting a root folder, viewing subfolders, and swapping their icons.

Key changes:
- Added `ChooseFoldersFolderCommand` and `SwapFolderIconCommand` for folder selection and icon swapping.
- Implemented `FolderService` and `IFolderService` for folder-related operations, including modifying `desktop.ini` files.
- Updated `Settings` and `SettingsService` to persist the folder root path.
- Enhanced `SwapperViewModel` with folder management properties, commands, and event handlers.
- Updated `SwapperUserControl.xaml` to include the "Folders" tab and related controls.
- Added `InverseBooleanToVisibilityConverter` for UI visibility logic.

Improved logging and user experience by restoring previously selected items after GUI refresh. Added a `DualSwapCommand` to unify icon-swapping behavior for both applications and folders.