### PR TITLE
Improve logging: thread safety, cleanup, shared file, v1.9.1

### DIFF
--- a/IconSwapperGui/App.xaml.cs
+++ b/IconSwapperGui/App.xaml.cs
@@ -9,36 +9,70 @@ namespace IconSwapperGui;
 /// </summary>
 public partial class App
 {
+    private static bool _isLoggerConfigured;
+    private static readonly object LoggerLock = new();
+
     protected override void OnStartup(StartupEventArgs e)
     {
-        string exeDirectory = AppDomain.CurrentDomain.BaseDirectory;
-        string logDirectory = Path.Combine(exeDirectory, "logs");
-
-        Directory.CreateDirectory(logDirectory);
-
-        string timestamp = DateTime.Now.ToString("yyyyMMdd-HHmmss");
-        string logFileName = $"iconswapper-{timestamp}.log";
-
-        Log.Logger = new LoggerConfiguration()
-            .MinimumLevel.Debug()
-            .Enrich.FromLogContext()
-            .WriteTo.File(
-                path: Path.Combine(logDirectory, logFileName),
-                outputTemplate:
-                "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:u3}] [{SourceContext}] {Message:lj}{NewLine}{Exception}",
-                retainedFileCountLimit: 30)
-            .CreateLogger();
-
-        Log.Information("Application starting up - Log file: {LogFileName}", logFileName);
-
-        AppDomain.CurrentDomain.UnhandledException += (s, ex) =>
-            Log.Fatal(ex.ExceptionObject as Exception, "Unhandled exception");
-
-        DispatcherUnhandledException += (s, ex) =>
+        lock (LoggerLock)
         {
-            Log.Fatal(ex.Exception, "Unhandled dispatcher exception");
-            ex.Handled = true;
-        };
+            if (!_isLoggerConfigured)
+            {
+                var exeDirectory = AppDomain.CurrentDomain.BaseDirectory;
+                var logDirectory = Path.Combine(exeDirectory, "logs");
+
+                Directory.CreateDirectory(logDirectory);
+
+                try
+                {
+                    var threshold = DateTime.UtcNow.AddDays(-7);
+                    foreach (var file in Directory.EnumerateFiles(logDirectory, "iconswapper-*.log"))
+                    {
+                        try
+                        {
+                            var fi = new FileInfo(file);
+                            if (fi.CreationTimeUtc < threshold)
+                                fi.Delete();
+                        }
+                        catch
+                        {
+                            // ignore file delete errors
+                        }
+                    }
+                }
+                catch
+                {
+                    // ignore enumerating errors
+                }
+
+                var timestamp = DateTime.Now.ToString("yyyyMMdd-HHmm");
+                var logFileName = $"iconswapper-{timestamp}.log";
+
+                Log.Logger = new LoggerConfiguration()
+                    .MinimumLevel.Debug()
+                    .Enrich.FromLogContext()
+                    .WriteTo.File(
+                        path: Path.Combine(logDirectory, logFileName),
+                        outputTemplate:
+                        "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:u3}] [{SourceContext}] {Message:lj}{NewLine}{Exception}",
+                        retainedFileCountLimit: 30,
+                        shared: true)
+                    .CreateLogger();
+
+                Log.Information("Application starting up - Log file: {LogFileName}", logFileName);
+
+                AppDomain.CurrentDomain.UnhandledException += (s, ex) =>
+                    Log.Fatal(ex.ExceptionObject as Exception, "Unhandled exception");
+
+                DispatcherUnhandledException += (s, ex) =>
+                {
+                    Log.Fatal(ex.Exception, "Unhandled dispatcher exception");
+                    ex.Handled = true;
+                };
+
+                _isLoggerConfigured = true;
+            }
+        }
 
         base.OnStartup(e);
     }

--- a/IconSwapperGui/IconSwapperGui.csproj
+++ b/IconSwapperGui/IconSwapperGui.csproj
@@ -7,7 +7,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <UseWPF>true</UseWPF>
         <ApplicationIcon>favicon.ico</ApplicationIcon>
-        <Version>1.9.0</Version>
+        <Version>1.9.1</Version>
         <Authors>Adam Phillips</Authors>
     </PropertyGroup>
 

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "LatestVersion": "1.9.0"
+  "LatestVersion": "1.9.1"
 }


### PR DESCRIPTION
Improve logging: thread safety, cleanup, shared file, v1.9.1

- Make logger initialization thread-safe and idempotent
- Delete log files older than 7 days on startup
- Change log file timestamp to minute precision
- Enable Serilog shared file mode for multi-process use
- Bump version to 1.9.1 in project and version.json