### PR TITLE
Downgrade to .NET 8.0, improve logging and update flow

### DIFF
--- a/IconSwapperGui.Core.UnitTests/IconSwapperGui.Core.UnitTests.csproj
+++ b/IconSwapperGui.Core.UnitTests/IconSwapperGui.Core.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net10.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
@@ -10,8 +10,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="coverlet.collector" Version="6.0.4" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
 		<PackageReference Include="NUnit" Version="4.4.0" />
 		<PackageReference Include="NUnit.Analyzers" Version="4.11.2">

--- a/IconSwapperGui.Core/IconSwapperGui.Core.csproj
+++ b/IconSwapperGui.Core/IconSwapperGui.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net10.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/IconSwapperGui.Infrastructure.UnitTests/IconSwapperGui.Infrastructure.UnitTests.csproj
+++ b/IconSwapperGui.Infrastructure.UnitTests/IconSwapperGui.Infrastructure.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -18,7 +18,7 @@
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/IconSwapperGui.Infrastructure/IconSwapperGui.Infrastructure.csproj
+++ b/IconSwapperGui.Infrastructure/IconSwapperGui.Infrastructure.csproj
@@ -2,8 +2,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
-    <PackageReference Include="System.Windows.Extensions" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="System.Windows.Extensions" Version="8.0.0" />
     <PackageReference Include="Velopack" Version="0.0.1298" />
   </ItemGroup>
 
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/IconSwapperGui.Infrastructure/Services/FileLoggingService.cs
+++ b/IconSwapperGui.Infrastructure/Services/FileLoggingService.cs
@@ -5,7 +5,7 @@ namespace IconSwapperGui.Infrastructure.Services;
 
 public class FileLoggingService : ILoggingService
 {
-    private readonly Lock _lockObject = new();
+    private readonly object _lockObject = new();
     private readonly string _logFilePath;
 
     public FileLoggingService()

--- a/IconSwapperGui.Infrastructure/Services/SettingsService.cs
+++ b/IconSwapperGui.Infrastructure/Services/SettingsService.cs
@@ -143,7 +143,14 @@ public class SettingsService : ISettingsService
 
         try
         {
-            File.Replace(tempPath, _settingsPath, null);
+            if (File.Exists(_settingsPath))
+            {
+                File.Replace(tempPath, _settingsPath, null);
+            }
+            else
+            {
+                File.Move(tempPath, _settingsPath, overwrite: true);
+            }
         }
         catch (PlatformNotSupportedException)
         {

--- a/IconSwapperGui.Infrastructure/Services/VelopackUpdateService.cs
+++ b/IconSwapperGui.Infrastructure/Services/VelopackUpdateService.cs
@@ -3,43 +3,66 @@ using IconSwapperGui.Core.Interfaces;
 using CoreUpdateInfo = IconSwapperGui.Core.Models.UpdateInfo;
 using Velopack;
 using Velopack.Sources;
+using Velopack.Locators;
+using Velopack.Logging;
 
 namespace IconSwapperGui.Infrastructure.Services;
 
 public class VelopackUpdateService : IUpdateService
 {
     private readonly UpdateManager _updateManager;
+    private readonly ILoggingService _loggingService;
     private UpdateInfo? _cachedVelopackUpdate;
 
-    public VelopackUpdateService()
+    public VelopackUpdateService(ILoggingService loggingService)
     {
-        var githubSource = new GithubSource(
-            $"https://github.com/{AppInfo.GitHubRepositoryOwner}/{AppInfo.GitHubRepositoryName}",
-            null,
-            false
-        );
-        
-        _updateManager = new UpdateManager(githubSource);
+        _loggingService = loggingService;
+
+        try
+        {
+            var githubSource = new GithubSource(
+                $"https://github.com/{AppInfo.GitHubRepositoryOwner}/{AppInfo.GitHubRepositoryName}",
+                null,
+                false
+            );
+
+            var velopackLogger = new LoggingServiceAdapter(loggingService);
+            var locator = VelopackLocator.CreateDefaultForPlatform(velopackLogger);
+
+            _updateManager = new UpdateManager(githubSource, null, locator);
+            _loggingService.LogInfo(
+                $"VelopackUpdateService initialized with GitHub source: {AppInfo.GitHubRepositoryOwner}/{AppInfo.GitHubRepositoryName}");
+        }
+        catch (Exception ex)
+        {
+            _loggingService.LogError("Failed to initialize VelopackUpdateService", ex);
+            throw;
+        }
     }
 
     public string GetCurrentVersion()
     {
-        return AppInfo.GetApplicationVersion();
+        var version = AppInfo.GetApplicationVersion();
+        _loggingService.LogInfo($"Current application version: {version}");
+        return version;
     }
 
     public async Task<CoreUpdateInfo?> CheckForUpdatesAsync()
     {
         try
         {
+            _loggingService.LogInfo("Checking for updates...");
             var updateInfo = await _updateManager.CheckForUpdatesAsync();
-            
+
             if (updateInfo == null)
             {
+                _loggingService.LogInfo("No updates available");
                 _cachedVelopackUpdate = null;
                 return null;
             }
 
             _cachedVelopackUpdate = updateInfo;
+            _loggingService.LogInfo($"Update available: {updateInfo.TargetFullRelease.Version}");
 
             return new CoreUpdateInfo
             {
@@ -49,8 +72,9 @@ public class VelopackUpdateService : IUpdateService
                 PublishedAt = DateTime.Now
             };
         }
-        catch
+        catch (Exception ex)
         {
+            _loggingService.LogError("Failed to check for updates", ex);
             _cachedVelopackUpdate = null;
             return null;
         }
@@ -60,25 +84,69 @@ public class VelopackUpdateService : IUpdateService
     {
         try
         {
+            _loggingService.LogInfo($"Starting update process for version: {updateInfo.Version}");
+
             if (_cachedVelopackUpdate == null)
             {
+                _loggingService.LogInfo("No cached update info, checking for updates...");
                 var checkResult = await _updateManager.CheckForUpdatesAsync();
                 if (checkResult == null)
+                {
+                    _loggingService.LogWarning("No update found during check");
                     return false;
-                
+                }
+
                 _cachedVelopackUpdate = checkResult;
+                _loggingService.LogInfo($"Update found: {_cachedVelopackUpdate.TargetFullRelease.Version}");
             }
 
+            _loggingService.LogInfo("Downloading update...");
             await _updateManager.DownloadUpdatesAsync(_cachedVelopackUpdate);
-            
+            _loggingService.LogInfo("Update downloaded successfully");
+
+            _loggingService.LogInfo("Applying update and restarting...");
             _updateManager.ApplyUpdatesAndRestart(_cachedVelopackUpdate.TargetFullRelease);
-            
+
             return true;
         }
-        catch
+        catch (Exception ex)
         {
+            _loggingService.LogError("Failed to download and install update", ex);
             return false;
         }
     }
 }
 
+/// <summary>
+/// Adapter to bridge Velopack's IVelopackLogger to our ILoggingService
+/// </summary>
+internal class LoggingServiceAdapter : IVelopackLogger
+{
+    private readonly ILoggingService _loggingService;
+
+    public LoggingServiceAdapter(ILoggingService loggingService)
+    {
+        _loggingService = loggingService;
+    }
+
+    public void Log(VelopackLogLevel logLevel, string? message, Exception? exception)
+    {
+        var logMessage = $"[VELOPACK] {message}";
+
+        switch (logLevel)
+        {
+            case VelopackLogLevel.Debug:
+                _loggingService.LogDebug(logMessage);
+                break;
+            case VelopackLogLevel.Information:
+                _loggingService.LogInfo(logMessage);
+                break;
+            case VelopackLogLevel.Warning:
+                _loggingService.LogWarning(logMessage);
+                break;
+            case VelopackLogLevel.Error:
+                _loggingService.LogError(logMessage, exception);
+                break;
+        }
+    }
+}

--- a/IconSwapperGui.UI.UnitTests/IconSwapperGui.UI.UnitTests.csproj
+++ b/IconSwapperGui.UI.UnitTests/IconSwapperGui.UI.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net10.0-windows</TargetFramework>
+		<TargetFramework>net8.0-windows</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
@@ -18,7 +18,7 @@
 		</PackageReference>
 		<PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
 	</ItemGroup>
 

--- a/IconSwapperGui.UI/IconSwapperGui.UI.csproj
+++ b/IconSwapperGui.UI/IconSwapperGui.UI.csproj
@@ -28,14 +28,14 @@
 
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
 		<PackageReference Include="Velopack" Version="0.0.1298" />
 		<PackageReference Include="WindowsAPICodePack" Version="8.0.14" />
 	</ItemGroup>
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net10.0-windows</TargetFramework>
+		<TargetFramework>net8.0-windows</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseWPF>true</UseWPF>


### PR DESCRIPTION
Downgrade to .NET 8.0, improve logging and update flow

All projects now target .NET 8.0 for improved compatibility. Updated package references to .NET 8.0-compatible versions. Replaced custom Lock with standard object in FileLoggingService. Enhanced SettingsService to avoid exceptions on first save by moving temp files if needed. Refactored VelopackUpdateService to require ILoggingService, added detailed logging, and introduced LoggingServiceAdapter to bridge Velopack logging. These changes improve error handling, update management, and overall reliability.