### PR TITLE
Implemented general bug fixes and launch at startup

### DIFF
--- a/IconSwapperGui.Core/Interfaces/IStartupService.cs
+++ b/IconSwapperGui.Core/Interfaces/IStartupService.cs
@@ -1,0 +1,8 @@
+namespace IconSwapperGui.Core.Interfaces;
+
+public interface IStartupService
+{
+    void EnableStartup();
+    void DisableStartup();
+    bool IsStartupEnabled();
+}

--- a/IconSwapperGui.Core/Models/Settings/GeneralSettings.cs
+++ b/IconSwapperGui.Core/Models/Settings/GeneralSettings.cs
@@ -3,4 +3,5 @@
 public class GeneralSettings
 {
     public bool CheckForUpdates { get; set; } = true;
+    public bool LaunchAtStartup { get; set; } = false;
 }

--- a/IconSwapperGui.Infrastructure/Services/StartupService.cs
+++ b/IconSwapperGui.Infrastructure/Services/StartupService.cs
@@ -1,0 +1,79 @@
+using System.Diagnostics;
+using System.Reflection;
+using Microsoft.Win32;
+using IconSwapperGui.Core.Interfaces;
+
+namespace IconSwapperGui.Infrastructure.Services;
+
+public class StartupService : IStartupService
+{
+    private const string RunKeyPath = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Run";
+    private const string AppName = "IconSwapperGui";
+
+    public void EnableStartup()
+    {
+        try
+        {
+            using var key = Registry.CurrentUser.OpenSubKey(RunKeyPath, true);
+            if (key == null)
+                return;
+
+            var executablePath = GetExecutablePath();
+            if (string.IsNullOrEmpty(executablePath))
+                return;
+
+            key.SetValue(AppName, $"\"{executablePath}\"");
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Failed to enable startup: {ex.Message}");
+        }
+    }
+
+    public void DisableStartup()
+    {
+        try
+        {
+            using var key = Registry.CurrentUser.OpenSubKey(RunKeyPath, true);
+            if (key == null)
+                return;
+
+            if (key.GetValue(AppName) != null)
+            {
+                key.DeleteValue(AppName, false);
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Failed to disable startup: {ex.Message}");
+        }
+    }
+
+    public bool IsStartupEnabled()
+    {
+        try
+        {
+            using var key = Registry.CurrentUser.OpenSubKey(RunKeyPath, false);
+            if (key == null)
+                return false;
+
+            var value = key.GetValue(AppName) as string;
+            return !string.IsNullOrEmpty(value);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Failed to check startup status: {ex.Message}");
+            return false;
+        }
+    }
+
+    private static string GetExecutablePath()
+    {
+        var processPath = Environment.ProcessPath;
+        if (!string.IsNullOrEmpty(processPath))
+            return processPath;
+
+        var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
+        return assembly.Location;
+    }
+}

--- a/IconSwapperGui.UI.UnitTests/Converters/ViewModelToViewConverterTests.cs
+++ b/IconSwapperGui.UI.UnitTests/Converters/ViewModelToViewConverterTests.cs
@@ -51,8 +51,9 @@ public class ViewModelToViewConverterTests
         var themeMock = new Mock<IThemeService>();
         var notifMock = new Mock<INotificationService>();
         var updateMock = new Mock<IUpdateService>();
+        var startupMock = new Mock<IStartupService>();
 
-        var vm = new SettingsViewModel(settingsMock.Object, themeMock.Object, notifMock.Object, updateMock.Object);
+        var vm = new SettingsViewModel(settingsMock.Object, themeMock.Object, notifMock.Object, updateMock.Object, startupMock.Object);
 
         var view = conv.Convert(vm, typeof(object), null, CultureInfo.InvariantCulture);
         Assert.That(view, Is.Not.Null);

--- a/IconSwapperGui.UI.UnitTests/ViewModels/PixelArtEditorViewModelTests.cs
+++ b/IconSwapperGui.UI.UnitTests/ViewModels/PixelArtEditorViewModelTests.cs
@@ -1,0 +1,157 @@
+using Moq;
+using IconSwapperGui.Core.Interfaces;
+using IconSwapperGui.UI.ViewModels;
+using IconSwapperGui.UI.Services.PixelArtEditor;
+using System.Windows.Media;
+
+namespace IconSwapperGui.UI.UnitTests.ViewModels;
+
+[TestFixture]
+public class PixelArtEditorViewModelTests
+{
+    private Mock<INotificationService> _notificationServiceMock;
+    private Mock<ISettingsService> _settingsServiceMock;
+    private Mock<ILoggingService> _loggingServiceMock;
+    private PixelArtExportService _exportService;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _notificationServiceMock = new Mock<INotificationService>();
+        _settingsServiceMock = new Mock<ISettingsService>();
+        _loggingServiceMock = new Mock<ILoggingService>();
+        
+        var iconCreatorServiceMock = new Mock<IIconCreatorService>();
+        _exportService = new PixelArtExportService(iconCreatorServiceMock.Object);
+    }
+
+    [Test]
+    public void ApplyLayout_WithSmallCanvasSize_AllowsToolsToWork()
+    {
+        var vm = CreateViewModel();
+
+        vm.Rows = 10;
+        vm.Columns = 10;
+        vm.ApplyLayoutCommand.Execute(null);
+
+        Assert.That(vm.Layers.Count, Is.EqualTo(1));
+        Assert.That(vm.Layers[0].PixelsArgb.Length, Is.EqualTo(100));
+        Assert.That(vm.PixelsArgb.Length, Is.EqualTo(100));
+    }
+
+    [Test]
+    public void ApplyLayout_WithSmallCanvasSize_ToolsCanDrawPixels()
+    {
+        var vm = CreateViewModel();
+
+        vm.Rows = 10;
+        vm.Columns = 10;
+        vm.ApplyLayoutCommand.Execute(null);
+        vm.SelectedColor = Colors.Red;
+
+        vm.BeginStroke(0);
+
+        var layerPixels = vm.Layers[0].PixelsArgb;
+        Assert.That(layerPixels[0], Is.Not.EqualTo(0u));
+    }
+
+    [Test]
+    public void ApplyLayout_WithLargeCanvasSize_AllowsToolsToWork()
+    {
+        var vm = CreateViewModel();
+
+        vm.Rows = 256;
+        vm.Columns = 256;
+        vm.ApplyLayoutCommand.Execute(null);
+
+        Assert.That(vm.Layers.Count, Is.EqualTo(1));
+        Assert.That(vm.Layers[0].PixelsArgb.Length, Is.EqualTo(65536));
+        Assert.That(vm.PixelsArgb.Length, Is.EqualTo(65536));
+    }
+
+    [Test]
+    public void ApplyLayout_WithZeroRows_DoesNotApplyLayout()
+    {
+        var vm = CreateViewModel();
+
+        vm.Rows = 0;
+        vm.Columns = 10;
+        vm.ApplyLayoutCommand.Execute(null);
+
+        Assert.That(vm.Layers[0].PixelsArgb.Length, Is.EqualTo(1024));
+    }
+
+    [Test]
+    public void ApplyLayout_WithZeroColumns_DoesNotApplyLayout()
+    {
+        var vm = CreateViewModel();
+
+        vm.Rows = 10;
+        vm.Columns = 0;
+        vm.ApplyLayoutCommand.Execute(null);
+
+        Assert.That(vm.Layers[0].PixelsArgb.Length, Is.EqualTo(1024));
+    }
+
+    [Test]
+    public void ApplyLayout_WithNegativeRows_DoesNotApplyLayout()
+    {
+        var vm = CreateViewModel();
+
+        vm.Rows = -10;
+        vm.Columns = 10;
+        vm.ApplyLayoutCommand.Execute(null);
+
+        Assert.That(vm.Layers[0].PixelsArgb.Length, Is.EqualTo(1024));
+    }
+
+    [TestCase(1, 1)]
+    [TestCase(5, 5)]
+    [TestCase(10, 10)]
+    [TestCase(32, 32)]
+    [TestCase(64, 64)]
+    [TestCase(96, 96)]
+    [TestCase(128, 128)]
+    [TestCase(256, 256)]
+    [TestCase(512, 512)]
+    public void ApplyLayout_WithVariousCanvasSizes_ResizesLayersCorrectly(int rows, int columns)
+    {
+        var vm = CreateViewModel();
+
+        vm.Rows = rows;
+        vm.Columns = columns;
+        vm.ApplyLayoutCommand.Execute(null);
+
+        var expectedLength = rows * columns;
+        Assert.That(vm.Layers[0].PixelsArgb.Length, Is.EqualTo(expectedLength));
+        Assert.That(vm.PixelsArgb.Length, Is.EqualTo(expectedLength));
+    }
+
+    [Test]
+    public void ApplyLayout_WithMultipleLayers_ResizesAllLayers()
+    {
+        var vm = CreateViewModel();
+
+        vm.AddLayerCommand.Execute(null);
+        vm.AddLayerCommand.Execute(null);
+
+        vm.Rows = 10;
+        vm.Columns = 10;
+        vm.ApplyLayoutCommand.Execute(null);
+
+        Assert.That(vm.Layers.Count, Is.EqualTo(3));
+        Assert.That(vm.Layers[0].PixelsArgb.Length, Is.EqualTo(100));
+        Assert.That(vm.Layers[1].PixelsArgb.Length, Is.EqualTo(100));
+        Assert.That(vm.Layers[2].PixelsArgb.Length, Is.EqualTo(100));
+    }
+
+    private PixelArtEditorViewModel CreateViewModel()
+    {
+        return new PixelArtEditorViewModel(
+            _notificationServiceMock.Object,
+            _settingsServiceMock.Object,
+            _loggingServiceMock.Object,
+            _exportService
+        );
+    }
+}

--- a/IconSwapperGui.UI.UnitTests/ViewModels/SettingsViewModelTests.cs
+++ b/IconSwapperGui.UI.UnitTests/ViewModels/SettingsViewModelTests.cs
@@ -23,8 +23,10 @@ public class SettingsViewModelTests
         var themeMock = new Mock<IThemeService>();
         var notifMock = new Mock<INotificationService>();
         var updateMock = new Mock<IUpdateService>();
+        var startupService = new Mock<IStartupService>();
 
-        var vm = new SettingsViewModel(settingsMock.Object, themeMock.Object, notifMock.Object, updateMock.Object);
+        var vm = new SettingsViewModel(settingsMock.Object, themeMock.Object, notifMock.Object, updateMock.Object,
+            startupService.Object);
 
         Assert.Multiple(() => { Assert.That(vm.CheckForUpdates, Is.True); });
     }
@@ -43,8 +45,10 @@ public class SettingsViewModelTests
         var themeMock = new Mock<IThemeService>();
         var notifMock = new Mock<INotificationService>();
         var updateMock = new Mock<IUpdateService>();
+        var startupService = new Mock<IStartupService>();
 
-        var vm = new SettingsViewModel(settingsMock.Object, themeMock.Object, notifMock.Object, updateMock.Object);
+        var vm = new SettingsViewModel(settingsMock.Object, themeMock.Object, notifMock.Object, updateMock.Object,
+            startupService.Object);
 
         vm.ResetToDefaultsCommand.Execute(null);
 

--- a/IconSwapperGui.UI/App.xaml.cs
+++ b/IconSwapperGui.UI/App.xaml.cs
@@ -50,6 +50,7 @@ public partial class App : Application
         services.AddSingleton<ILoggingService, FileLoggingService>();
         services.AddSingleton<IUpdateService, VelopackUpdateService>();
         services.AddSingleton<IElevationService, ElevationService>();
+        services.AddSingleton<IStartupService, StartupService>();
         services.AddSingleton<IFileSystemWatcherService, FileSystemWatcherService>();
         services.AddSingleton<IFolderManagementService, FolderManagementService>();
         services.AddSingleton<IIconHistoryService, IconHistoryService>();
@@ -93,6 +94,7 @@ public partial class App : Application
         var updateService = _serviceProvider.GetRequiredService<IUpdateService>();
         var notificationService = _serviceProvider.GetRequiredService<INotificationService>();
         var themeService = _serviceProvider.GetRequiredService<IThemeService>();
+        var startupService = _serviceProvider.GetRequiredService<IStartupService>();
         _serviceProvider.GetRequiredService<ThemeApplier>();
 
         await settingsService.LoadSettingsAsync();
@@ -100,6 +102,19 @@ public partial class App : Application
         loggingService.IsEnabled = settingsService.Settings.Advanced.EnableLogging;
 
         loggingService.LogInfo("Application started.");
+
+        var isStartupEnabled = startupService.IsStartupEnabled();
+        if (settingsService.Settings.General.LaunchAtStartup != isStartupEnabled)
+        {
+            if (settingsService.Settings.General.LaunchAtStartup)
+            {
+                startupService.EnableStartup();
+            }
+            else
+            {
+                startupService.DisableStartup();
+            }
+        }
 
         var main = _serviceProvider.GetRequiredService<MainWindow>();
         main.Show();

--- a/IconSwapperGui.UI/Converters/StringNotEmptyToVisibilityConverter.cs
+++ b/IconSwapperGui.UI/Converters/StringNotEmptyToVisibilityConverter.cs
@@ -1,0 +1,20 @@
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace IconSwapperGui.UI.Converters;
+
+public class StringNotEmptyToVisibilityConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        var str = value as string;
+        var isEmpty = string.IsNullOrWhiteSpace(str);
+        return isEmpty ? Visibility.Collapsed : Visibility.Visible;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/IconSwapperGui.UI/IconSwapperGui.UI.csproj
+++ b/IconSwapperGui.UI/IconSwapperGui.UI.csproj
@@ -40,7 +40,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UseWPF>true</UseWPF>
 		<AssemblyName>IconSwapperGui</AssemblyName>
-		<Version>2.0.0</Version>
+		<Version>2.0.1</Version>
 		<ApplicationIcon>favicon.ico</ApplicationIcon>
 		<PackageVersion>$(Version)</PackageVersion>
 		<InformationalVersion>$(Version)</InformationalVersion>

--- a/IconSwapperGui.UI/Services/Swapper/IconManagementService.cs
+++ b/IconSwapperGui.UI/Services/Swapper/IconManagementService.cs
@@ -44,13 +44,13 @@ public class IconManagementService(ILoggingService logger) : IIconManagementServ
             foreach (var extension in enumerable)
             {
                 var searchPattern = $"*.{extension.TrimStart('*', '.')}";
-                var files = Directory.GetFiles(folderPath, searchPattern);
-                logger.LogInfo($"Found {files.Length} files with extension {extension}");
+                var files = Directory.GetFiles(folderPath, searchPattern, SearchOption.AllDirectories);
+                logger.LogInfo($"Found {files.Length} files with extension {extension} (including subdirectories)");
 
                 icons.AddRange(files.Select(file => new Icon(Path.GetFileName(file), file)));
             }
 
-            logger.LogInfo($"Successfully loaded {icons.Count} total icons from {folderPath}");
+            logger.LogInfo($"Successfully loaded {icons.Count} total icons from {folderPath} and subdirectories");
             return icons;
         }
         catch (IOException ex)

--- a/IconSwapperGui.UI/ViewModels/PixelArtEditorViewModel.cs
+++ b/IconSwapperGui.UI/ViewModels/PixelArtEditorViewModel.cs
@@ -241,14 +241,28 @@ public partial class PixelArtEditorViewModel : ObservableObject
         }
 
         ResizeBuffer(Rows, Columns);
+        
+        foreach (var layer in Layers)
+        {
+            layer.Resize(Rows, Columns);
+        }
+        
         ClearToBackground();
+        CompositeLayersIntoBuffer();
         LayoutInvalidated?.Invoke();
     }
 
     private bool PerformMaxSizeValidation(int rows, int columns)
     {
-        const int maxRows = 96;
-        const int maxColumns = 96;
+        const int maxRows = 512;
+        const int maxColumns = 512;
+
+        if (rows <= 0 || columns <= 0)
+        {
+            _loggingService.LogWarning($"Grid size must be positive - Rows: {rows}, Columns: {columns}");
+            _notificationService.AddNotification("Pixel Art Editor", "Grid size must be greater than zero.", NotificationType.Warning);
+            return false;
+        }
 
         if (rows <= maxRows && columns <= maxColumns)
         {
@@ -261,7 +275,7 @@ public partial class PixelArtEditorViewModel : ObservableObject
         var message = $"The grid size exceeds the maximum allowed values.\n\n" +
                       $"Maximum Rows: {maxRows}\nMaximum Columns: {maxColumns}";
 
-        _notificationService.AddNotification("Pixel Art Edtior", message, NotificationType.Warning);
+        _notificationService.AddNotification("Pixel Art Editor", message, NotificationType.Warning);
 
         return false;
     }

--- a/IconSwapperGui.UI/ViewModels/SettingsViewModel.cs
+++ b/IconSwapperGui.UI/ViewModels/SettingsViewModel.cs
@@ -17,6 +17,7 @@ public partial class SettingsViewModel : ObservableObject
     private readonly ISettingsService _settingsService;
     private readonly IThemeService _themeService;
     private readonly IUpdateService _updateService;
+    private readonly IStartupService _startupService;
 
     // Application Settings
     public ObservableCollection<string> ShortcutLocations { get; }
@@ -37,6 +38,7 @@ public partial class SettingsViewModel : ObservableObject
 
     // General Settings
     [ObservableProperty] private bool _checkForUpdates;
+    [ObservableProperty] private bool _launchAtStartup;
 
     // Update check UI
     [ObservableProperty] private bool _isCheckingForUpdates;
@@ -72,12 +74,14 @@ public partial class SettingsViewModel : ObservableObject
         ISettingsService settingsService,
         IThemeService themeService,
         INotificationService notificationService,
-        IUpdateService updateService)
+        IUpdateService updateService,
+        IStartupService startupService)
     {
         _settingsService = settingsService;
         _themeService = themeService;
         _notificationService = notificationService;
         _updateService = updateService;
+        _startupService = startupService;
 
         ShortcutLocations = new ObservableCollection<string>(_settingsService.Settings.Application.ShortcutLocations);
         IconLocations = new ObservableCollection<string>(_settingsService.Settings.Application.IconLocations);
@@ -90,6 +94,7 @@ public partial class SettingsViewModel : ObservableObject
         _isLightTheme = _settingsService.Settings.Appearance.Theme == ThemeMode.Light;
         _isDarkTheme = _settingsService.Settings.Appearance.Theme == ThemeMode.Dark;
         _checkForUpdates = _settingsService.Settings.General.CheckForUpdates;
+        _launchAtStartup = _settingsService.Settings.General.LaunchAtStartup;
 
         _playSound = _settingsService.Settings.Notifications.PlaySound;
 
@@ -373,6 +378,24 @@ public partial class SettingsViewModel : ObservableObject
         if (e.PropertyName == nameof(CheckForUpdates))
         {
             _settingsService.Settings.General.CheckForUpdates = CheckForUpdates;
+
+            await _settingsService.SaveSettingsAsync();
+
+            return;
+        }
+
+        if (e.PropertyName == nameof(LaunchAtStartup))
+        {
+            _settingsService.Settings.General.LaunchAtStartup = LaunchAtStartup;
+
+            if (LaunchAtStartup)
+            {
+                _startupService.EnableStartup();
+            }
+            else
+            {
+                _startupService.DisableStartup();
+            }
 
             await _settingsService.SaveSettingsAsync();
 

--- a/IconSwapperGui.UI/Views/SettingsView.xaml
+++ b/IconSwapperGui.UI/Views/SettingsView.xaml
@@ -358,6 +358,11 @@
                         TitleText="Check for Updates"
                         DescriptionText="Automatically check for application updates"
                         IsChecked="{Binding CheckForUpdates}" />
+
+                    <templates:SettingToggleItem
+                        TitleText="Launch at Startup"
+                        DescriptionText="Automatically start the application when you log in to Windows"
+                        IsChecked="{Binding LaunchAtStartup}" />
                 </StackPanel>
 
                 <!-- Notifications Section -->

--- a/IconSwapperGui.UI/Views/SettingsView.xaml
+++ b/IconSwapperGui.UI/Views/SettingsView.xaml
@@ -16,6 +16,7 @@
             </ResourceDictionary.MergedDictionaries>
             <converters:SectionVisibilityConverter x:Key="SectionVisibilityConverter" />
             <converters:BooleanNegationConverter x:Key="BooleanNegationConverter" />
+            <converters:StringNotEmptyToVisibilityConverter x:Key="StringNotEmptyToVisibilityConverter" />
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -446,7 +447,8 @@
                                     BorderBrush="{DynamicResource AccentBrush}"
                                     CornerRadius="6"
                                     Padding="12"
-                                    Margin="0,0,0,16">
+                                    Margin="0,0,0,16"
+                                    Visibility="{Binding LastCheckedDate, Converter={StaticResource StringNotEmptyToVisibilityConverter}}">
                                 <Grid>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="Auto" />


### PR DESCRIPTION
Pixel Art Editor now allows any size up to 512x512 without restriction after it was identified that if using a smaller canvas size than 10x10, the view would render 10x10, but it would actually be 100x100

Swapper now supports adding icons that are organised in subfolders within a parent.

Launch at startup has been added back to the application and is available under Settings -> General

Check for updates section has been updated to only show the status box after clicking check for updates